### PR TITLE
Q3ptrlist removal

### DIFF
--- a/src/CppGenerator/CppRefType.h
+++ b/src/CppGenerator/CppRefType.h
@@ -44,13 +44,13 @@ class CppRefType
 public:
     enum Weight { Low, Medium, High, Strong };
 
-    static bool add(UmlClass *, Q3PtrList<CppRefType> &, bool incl, bool hight = FALSE);
-    static bool add(const WrapperStr &, Q3PtrList<CppRefType> &, bool incl);
-    static bool add(const UmlTypeSpec & t, Q3PtrList<CppRefType> & l, bool incl);
-    static void remove(UmlClass *, Q3PtrList<CppRefType> & l);
-    static void remove(const WrapperStr &, Q3PtrList<CppRefType> & l);
-    static void force_ref(UmlClass * cl, Q3PtrList<CppRefType> & l);
-    static void compute(Q3PtrList<CppRefType> & dependencies,
+    static bool add(UmlClass *, QList<CppRefType *> &, bool incl, bool hight = FALSE);
+    static bool add(const WrapperStr &, QList<CppRefType *> &, bool incl);
+    static bool add(const UmlTypeSpec & t, QList<CppRefType *> & l, bool incl);
+    static void remove(UmlClass *, QList<CppRefType *> & l);
+    static void remove(const WrapperStr &, QList<CppRefType *> & l);
+    static void force_ref(UmlClass * cl, QList<CppRefType *> & l);
+    static void compute(QList<CppRefType *> & dependencies,
                         const WrapperStr & hdef, const WrapperStr & srcdef,
                         WrapperStr & h_incl,  WrapperStr & decl, WrapperStr & src_incl,
                         UmlArtifact * who);

--- a/src/CppGenerator/UmlArtifact.cpp
+++ b/src/CppGenerator/UmlArtifact.cpp
@@ -136,7 +136,7 @@ void UmlArtifact::generate()
         // compute dependencies
 
         bool all_in_h = (hdef.find("${all_includes}") != -1);
-        Q3PtrList<CppRefType> dependencies;
+        QList<CppRefType *> dependencies;
         unsigned n = cls.count();
         unsigned index;
 

--- a/src/CppGenerator/UmlAttribute.cpp
+++ b/src/CppGenerator/UmlAttribute.cpp
@@ -40,7 +40,7 @@
 #include "util.h"
 #include "misc/codec.h"
 
-void UmlAttribute::compute_dependency(Q3PtrList<CppRefType> & dependency,
+void UmlAttribute::compute_dependency(QList<CppRefType *> & dependency,
                                       const WrapperStr & cl_stereotype,
                                       bool all_in_h)
 {

--- a/src/CppGenerator/UmlAttribute.h
+++ b/src/CppGenerator/UmlAttribute.h
@@ -42,7 +42,7 @@ public:
     UmlAttribute(void * id, const WrapperStr & n)
         :  UmlBaseAttribute(id, n) {};
 
-    virtual void compute_dependency(Q3PtrList<CppRefType> & dependency,
+    virtual void compute_dependency(QList<CppRefType *> & dependency,
                                     const WrapperStr & cl_stereotype,
                                     bool all_in_h);
     virtual void generate_decl(aVisibility & current_visibility, QTextStream & f_h,

--- a/src/CppGenerator/UmlClass.cpp
+++ b/src/CppGenerator/UmlClass.cpp
@@ -51,7 +51,7 @@
 // the eventual class list where we are, used by write() to not generate
 // parent classes and template in the class declaration of the class
 
-Q3PtrList<UmlClass> UmlClass::context;
+QList<UmlClass *> UmlClass::context;
 Q3ValueList<UmlActualParameter> UmlClass::noactuals;
 
 WrapperStr UmlClass::cpp_stereotype()
@@ -84,7 +84,7 @@ void UmlClass::generate()
     }
 }
 
-void UmlClass::compute_dependencies(Q3PtrList<CppRefType> & dependencies,
+void UmlClass::compute_dependencies(QList<CppRefType *> & dependencies,
                                     bool all_in_h)
 {
     const WrapperStr dummy;
@@ -92,7 +92,7 @@ void UmlClass::compute_dependencies(Q3PtrList<CppRefType> & dependencies,
     compute_dependency(dependencies, dummy, all_in_h);
 }
 
-void UmlClass::compute_dependency(Q3PtrList<CppRefType> & dependencies,
+void UmlClass::compute_dependency(QList<CppRefType *> & dependencies,
                                   const WrapperStr &, bool all_in_h)
 {
     Q3PtrVector<UmlItem> ch = children();
@@ -563,9 +563,9 @@ void UmlClass::write(QTextStream & f, const UmlTypeSpec & t,
 void UmlClass::write(QTextStream & f, bool with_formals, BooL * is_template,
                      const Q3ValueList<UmlActualParameter> & actuals)
 {
-    if (context.findRef(this) == -1) {
+    if (! context.contains(this)) {
         if (parent()->kind() == aClass) {
-            if (context.findRef((UmlClass *) parent()) == -1) {
+            if (! context.contains((UmlClass *) parent())) {
                 // parent cannot have formals, but may have actuals
                 ((UmlClass *) parent())->write(f, FALSE, 0, actuals);
                 f << "::";

--- a/src/CppGenerator/UmlClass.h
+++ b/src/CppGenerator/UmlClass.h
@@ -52,7 +52,7 @@ class UmlClass : public UmlBaseClass
 private:
     bool managed;
 
-    static Q3PtrList<UmlClass> context;
+    static QList<UmlClass *> context;
 
     static Q3ValueList<UmlActualParameter> noactuals;
 
@@ -62,9 +62,9 @@ public:
 
     WrapperStr cpp_stereotype();
 
-    void compute_dependencies(Q3PtrList<CppRefType> &, bool all_in_h);
+    void compute_dependencies(QList<CppRefType *> &, bool all_in_h);
 
-    virtual void compute_dependency(Q3PtrList<CppRefType> & dependency,
+    virtual void compute_dependency(QList<CppRefType *> & dependency,
                                     const WrapperStr & cl_stereotype,
                                     bool all_in_h);
     virtual void generate_decl(aVisibility & current_visibility,

--- a/src/CppGenerator/UmlClassItem.h
+++ b/src/CppGenerator/UmlClassItem.h
@@ -47,7 +47,7 @@ public:
         : UmlBaseClassItem(id, n) {
     };
 
-    virtual void compute_dependency(Q3PtrList<CppRefType> & dependency,
+    virtual void compute_dependency(QList<CppRefType *> & dependency,
                                     const WrapperStr & cl_stereotype,
                                     bool all_in_h) = 0;
 

--- a/src/CppGenerator/UmlClassMember.cpp
+++ b/src/CppGenerator/UmlClassMember.cpp
@@ -153,7 +153,7 @@ void UmlClassMember::remove_arrays(WrapperStr & s)
 // Between template < and > I suppose that a type is not included
 // because I cannot know how the type is used and I do not want to
 // produce circular #include
-bool UmlClassMember::compute_dependency(Q3PtrList<CppRefType> & dependencies,
+bool UmlClassMember::compute_dependency(QList<CppRefType *> & dependencies,
                                         WrapperStr decl, const UmlTypeSpec & t,
                                         bool force_incl)
 {

--- a/src/CppGenerator/UmlClassMember.h
+++ b/src/CppGenerator/UmlClassMember.h
@@ -47,7 +47,7 @@ public:
     static void remove_comments(WrapperStr & s);
     static void remove_arrays(WrapperStr & s);
     static void remove_preprocessor(WrapperStr & s);
-    static bool compute_dependency(Q3PtrList<CppRefType> & dependency,
+    static bool compute_dependency(QList<CppRefType *> & dependency,
                                    WrapperStr decl, const UmlTypeSpec &,
                                    bool force_incl = FALSE);
 

--- a/src/CppGenerator/UmlExtraClassMember.cpp
+++ b/src/CppGenerator/UmlExtraClassMember.cpp
@@ -35,7 +35,7 @@
 #include "UmlExtraClassMember.h"
 #include "UmlClass.h"
 
-void UmlExtraClassMember::compute_dependency(Q3PtrList<CppRefType> &,
+void UmlExtraClassMember::compute_dependency(QList<CppRefType *> &,
         const WrapperStr &,
         bool)
 {

--- a/src/CppGenerator/UmlExtraClassMember.h
+++ b/src/CppGenerator/UmlExtraClassMember.h
@@ -46,7 +46,7 @@ public:
     UmlExtraClassMember(void * id, const WrapperStr & n)
         : UmlBaseExtraClassMember(id, n) {};
 
-    virtual void compute_dependency(Q3PtrList<CppRefType> & dependency,
+    virtual void compute_dependency(QList<CppRefType *> & dependency,
                                     const WrapperStr & cl_stereotype,
                                     bool all_in_h);
     virtual void generate_decl(aVisibility & current_visibility,

--- a/src/CppGenerator/UmlOperation.cpp
+++ b/src/CppGenerator/UmlOperation.cpp
@@ -61,7 +61,7 @@ const int BodyPostfixLength = 28;
 // Between template < and > I suppose that a type is not included
 // because I cannot know how the type is used and I do not want to
 // produce circular #include
-void UmlOperation::compute_dependency(Q3PtrList<CppRefType> & dependencies,
+void UmlOperation::compute_dependency(QList<CppRefType *> & dependencies,
                                       const WrapperStr & cl_stereotype,
                                       bool all_in_h)
 {

--- a/src/CppGenerator/UmlOperation.h
+++ b/src/CppGenerator/UmlOperation.h
@@ -47,7 +47,7 @@ public:
     UmlOperation(void * id, const WrapperStr & n)
         : UmlBaseOperation(id, n) {};
 
-    virtual void compute_dependency(Q3PtrList<CppRefType> & dependency,
+    virtual void compute_dependency(QList<CppRefType *> & dependency,
                                     const WrapperStr & cl_stereotype,
                                     bool all_in_h);
     virtual void generate_decl(aVisibility & current_visibility, QTextStream & f_h,

--- a/src/CppGenerator/UmlRelation.cpp
+++ b/src/CppGenerator/UmlRelation.cpp
@@ -41,7 +41,7 @@
 #include "UmlCom.h"
 #include "util.h"
 
-void UmlRelation::compute_dependency(Q3PtrList<CppRefType> & dependencies,
+void UmlRelation::compute_dependency(QList<CppRefType *> & dependencies,
                                      const WrapperStr & cl_stereotype,
                                      bool all_in_h)
 {

--- a/src/CppGenerator/UmlRelation.h
+++ b/src/CppGenerator/UmlRelation.h
@@ -46,7 +46,7 @@ public:
         : UmlBaseRelation(id, n) {
     };
 
-    virtual void compute_dependency(Q3PtrList<CppRefType> & dependency,
+    virtual void compute_dependency(QList<CppRefType *> & dependency,
                                     const WrapperStr & cl_stereotype,
                                     bool all_in_h);
     void generate_inherit(const char *& sep, QTextStream & f_h,

--- a/src/CppReverse/BrowserNode.h
+++ b/src/CppReverse/BrowserNode.h
@@ -71,7 +71,7 @@ public:
 
 #include <q3ptrlist.h>
 
-class BrowserNodeList : public Q3PtrList<BrowserNode>
+class BrowserNodeList : public QList<BrowserNode *>
 {
 public:
     void search(BrowserNode * bn, int k, const QString & s, bool cs);

--- a/src/CppReverse/Class.cpp
+++ b/src/CppReverse/Class.cpp
@@ -94,7 +94,7 @@ Class * Class::reverse(ClassContainer * container, WrapperStr stereotype,
                        const Q3ValueList<FormalParameterList> & tmplts,
                        const WrapperStr & path, WrapperStr name
 #ifdef ROUNDTRIP
-                       , bool rndtrp, Q3PtrList<UmlItem> & expectedorder
+                       , bool rndtrp, QList<UmlItem *> & expectedorder
 #endif
                       )
 {
@@ -169,7 +169,7 @@ Class * Class::reverse(ClassContainer * container, WrapperStr stereotype,
     }
 
     bool roundtrip = FALSE;
-    Q3PtrList<UmlItem> expected_order;
+    QList<UmlItem *> expected_order;
 #else
     UmlClass * cl_uml = 0;
 #endif
@@ -571,7 +571,7 @@ Class * Class::reverse(ClassContainer * container, WrapperStr stereotype,
 void Class::declaration(const WrapperStr & name, const WrapperStr & stereotype,
                         const WrapperStr & decl
 #ifdef ROUNDTRIP
-                        , bool rndtrp, Q3PtrList<UmlItem> & expectedorder
+                        , bool rndtrp, QList<UmlItem *> & expectedorder
 #endif
                        )
 {
@@ -613,7 +613,7 @@ void Class::manage_member(WrapperStr s, aVisibility visibility,
                           ClassContainer * /*container*/,
                           const WrapperStr & path
 #ifdef ROUNDTRIP
-                          , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                          , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                          )
 {
@@ -1135,7 +1135,7 @@ void Class::manage_member(WrapperStr s, aVisibility visibility,
 Class * Class::reverse_enum(ClassContainer * container,
                             const WrapperStr & path, WrapperStr name
 #ifdef ROUNDTRIP
-                            , bool rndtrp, Q3PtrList<UmlItem> & expectedorder
+                            , bool rndtrp, QList<UmlItem *> & expectedorder
 #endif
                            )
 {
@@ -1206,8 +1206,9 @@ Class * Class::reverse_enum(ClassContainer * container,
     // enum definition
     Class * cl = container->define(name, "enum");
 
-    if(cl)
+    if(cl) {
         QLOG_INFO() << "RE got definition" << cl->stereotype.operator QString();
+    }
     //QLOG_INFO() << "RE got definition" << cl->uml;
     if ((cl == 0) || cl->reversedp)
     {
@@ -1258,7 +1259,7 @@ Class * Class::reverse_enum(ClassContainer * container,
         expectedorder.append(cl_uml);
 
     bool roundtrip;
-    Q3PtrList<UmlItem> expected_order;
+    QList<UmlItem *> expected_order;
 
     if (cl_uml->is_created()) {
         Statistic::one_class_created_more();
@@ -1481,7 +1482,7 @@ Class * Class::reverse_enum(ClassContainer * container,
     bool Class::reverse_typedef(ClassContainer  * container, const WrapperStr & path,
                                 Q3ValueList<FormalParameterList> & tmplts
 #ifdef ROUNDTRIP
-                                , bool rndtrp, Q3PtrList<UmlItem> & expectedorder
+                                , bool rndtrp, QList<UmlItem *> & expectedorder
 #endif
                                )
     {

--- a/src/CppReverse/Class.h
+++ b/src/CppReverse/Class.h
@@ -62,7 +62,7 @@ protected:
     void manage_member(WrapperStr s, aVisibility visibility,
                        ClassContainer * container, const WrapperStr & path
 #ifdef ROUNDTRIP
-                       , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                       , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                       );
 
@@ -87,7 +87,7 @@ public:
     virtual void declaration(const WrapperStr & name, const WrapperStr & stereotype,
                              const WrapperStr & decl
 #ifdef ROUNDTRIP
-                             , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                             , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                             );
 
@@ -137,19 +137,19 @@ public:
                            const Q3ValueList<FormalParameterList> & tmplt,
                            const WrapperStr & path, WrapperStr name
 #ifdef ROUNDTRIP
-                           , bool rndtrp, Q3PtrList<UmlItem> & expectedorder
+                           , bool rndtrp, QList<UmlItem *> & expectedorder
 #endif
                           );
     static Class * reverse_enum(ClassContainer * container,
                                 const WrapperStr & path, WrapperStr name
 #ifdef ROUNDTRIP
-                                , bool rndtrp, Q3PtrList<UmlItem> & expectedorder
+                                , bool rndtrp, QList<UmlItem *> & expectedorder
 #endif
                                );
     static bool reverse_typedef(ClassContainer * container, const WrapperStr & path,
                                 Q3ValueList<FormalParameterList> & tmplts
 #ifdef ROUNDTRIP
-                                , bool rndtrp, Q3PtrList<UmlItem> & expectedorder
+                                , bool rndtrp, QList<UmlItem *> & expectedorder
 #endif
                                );
 };

--- a/src/CppReverse/ClassContainer.h
+++ b/src/CppReverse/ClassContainer.h
@@ -55,7 +55,7 @@ public:
     virtual void declaration(const WrapperStr & name, const WrapperStr & stereotype,
                              const WrapperStr & decl
 #ifdef ROUNDTRIP
-                             , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                             , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                             ) = 0;
 

--- a/src/CppReverse/Package.cpp
+++ b/src/CppReverse/Package.cpp
@@ -68,7 +68,7 @@ QRegExp * Package::DirFilter;
 QRegExp * Package::FileFilter;
 
 // the packages selected by the user to reverse them
-Q3PtrList<Package> Package::Choozen;
+QList<Package *> Package::Choozen;
 
 // all the classes presents in the environment, the
 // key is the full name including namespaces
@@ -359,9 +359,7 @@ int Package::count_file_number()
         file_number(h_path, TRUE, CppSettings::headerExtension())
         + file_number(src_path, TRUE, CppSettings::sourceExtension());
 
-    TreeItem * child;
-
-    for (child = firstChild(); child != 0; child = child->nextSibling())
+    foreach (TreeItem * child, children())
         if (((BrowserNode *) child)->isa_package())
             result += ((Package *) child)->count_file_number();
 
@@ -389,9 +387,7 @@ void Package::scan_dir()
     reverse_directory(h_path, TRUE, CppSettings::headerExtension(), TRUE);
     reverse_directory(src_path, TRUE, CppSettings::sourceExtension(), FALSE);
 
-    TreeItem * child;
-
-    for (child = firstChild(); child != 0; child = child->nextSibling())
+    foreach (TreeItem * child, children())
         if (((BrowserNode *) child)->isa_package())
             ((Package *) child)->scan_dir();
 }
@@ -478,10 +474,8 @@ void Package::scan_dirs(int & n)
     // count files
     UmlCom::message("count files ...");
 
-    Package * p;
-
     /* lgfreitas: This just counts the packages */
-    for (p = Choozen.first(); p != 0; p = Choozen.next()) {
+    foreach (Package *p, Choozen) {
         n += file_number(p->h_path, TRUE,
                          CppSettings::headerExtension())
              + file_number(p->src_path, TRUE,
@@ -494,8 +488,7 @@ void Package::scan_dirs(int & n)
     /* lgfreitas: This is where the reversing magic happens. It iterates
        through each package, asking for it to do the reversing on the
        given path */
-    for (p = Choozen.first(); p != 0; p = Choozen.next())
-    {
+    foreach (Package *p, Choozen) {
         p->reverse_directory(p->h_path, TRUE, CppSettings::headerExtension(), TRUE);
         p->reverse_directory(p->src_path, TRUE, CppSettings::sourceExtension(), FALSE);
     }
@@ -613,9 +606,7 @@ void Package::send_dir()
     reverse_directory(h_path, TRUE, CppSettings::headerExtension(), TRUE);
     reverse_directory(src_path, TRUE, CppSettings::sourceExtension(), FALSE);
 
-    TreeItem * child;
-
-    for (child = firstChild(); child != 0; child = child->nextSibling())
+    foreach (TreeItem * child, children())
         if (((BrowserNode *) child)->isa_package())
             ((Package *) child)->send_dir();
 }
@@ -631,9 +622,7 @@ void Package::send_dirs(int n, bool rec)
 
     set_step(2, n);
 
-    Package * p;
-
-    for (p = Choozen.first(); p != 0; p = Choozen.next()) {
+    foreach (Package *p, Choozen) {
         p->reverse_directory(p->h_path, rec, CppSettings::headerExtension(), TRUE);
         p->reverse_directory(p->src_path, rec, CppSettings::sourceExtension(), FALSE);
     }
@@ -926,7 +915,7 @@ void Package::reverse_toplevel_forms(WrapperStr f, bool sub_block)
                     Lex::come_back();
                     // do not manage 'struct {..} var;' or 'struct {..} f()' ...
 #ifdef ROUNDTRIP
-                    Q3PtrList<UmlItem> dummy;
+                    QList<UmlItem *> dummy;
 
                     Class::reverse(this, s, Formals, f, 0, FALSE, dummy);
 #else
@@ -948,7 +937,7 @@ void Package::reverse_toplevel_forms(WrapperStr f, bool sub_block)
                     Lex::come_back();
                     // do not manage 'enum {..} var;' or 'enum {..} f()' ...
 #ifdef ROUNDTRIP
-                    Q3PtrList<UmlItem> dummy;
+                    QList<UmlItem *> dummy;
 
                     Class::reverse_enum(this, f, 0, FALSE, dummy);
 #else
@@ -958,7 +947,7 @@ void Package::reverse_toplevel_forms(WrapperStr f, bool sub_block)
             }
             else if (s == "typedef") {
 #ifdef ROUNDTRIP
-                Q3PtrList<UmlItem> dummy;
+                QList<UmlItem *> dummy;
 
                 Class::reverse_typedef(this, f, Formals, FALSE, dummy);
 #else
@@ -1393,7 +1382,7 @@ void Package::define(WrapperStr name, Class * cl)
 void Package::declaration(const WrapperStr &, const WrapperStr &,
                           const WrapperStr &
 #ifdef ROUNDTRIP
-                          , bool, Q3PtrList<UmlItem> &
+                          , bool, QList<UmlItem *> &
 #endif
                          )
 {
@@ -1470,9 +1459,7 @@ Package * Package::find(QFileInfo * di)
 #endif
 
     QString s = di->fileName();
-    TreeItem * child;
-
-    for (child = firstChild(); child != 0; child = child->nextSibling())
+    foreach (TreeItem * child, children())
         if (((BrowserNode *) child)->isa_package() &&
             (child->text(0) == s))
             return (Package *) child;

--- a/src/CppReverse/Package.h
+++ b/src/CppReverse/Package.h
@@ -73,7 +73,7 @@ public:
     virtual void declaration(const WrapperStr & name, const WrapperStr & stereotype,
                              const WrapperStr & decl
 #ifdef ROUNDTRIP
-                             , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                             , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                             );
 
@@ -129,7 +129,7 @@ private:
     WrapperStr src_path;	// empty or finish by a /
 
     static QApplication * app;
-    static Q3PtrList<Package> Choozen; /* List of chosen "packages" to reverse */
+    static QList<Package *> Choozen; /* List of chosen "packages" to reverse */
     static int Nfiles;
     static bool Scan;
     static Package * Root;
@@ -137,7 +137,7 @@ private:
     static QRegExp * FileFilter;
     //static Package * Unknown;
     static Q3ValueList<FormalParameterList> Formals;
-    static Q3PtrList<UmlClass> UsedClasses;
+    static QList<UmlClass *> UsedClasses;
 
     static NDict<Class> Declared;
     static NDict<Class> Defined;

--- a/src/CppReverse/TreeItem.h
+++ b/src/CppReverse/TreeItem.h
@@ -39,14 +39,14 @@
 
 #else
 
-#include <q3ptrlist.h>
 #include <qstring.h>
+#include <QList>
 
 class TreeItem
 {
 private:
     TreeItem * its_parent;
-    Q3PtrList<TreeItem> its_children;
+    QList<TreeItem *> its_children;
     QString its_name;
 
 public:
@@ -62,12 +62,10 @@ public:
         return its_parent;
     };
 
-    TreeItem * firstChild() {
-        return its_children.first();
-    };
-    TreeItem * nextSibling() {
-        return its_parent->its_children.next();
-    };
+    const QList<TreeItem *> &children()
+    {
+        return its_children;
+    }
 };
 
 #endif

--- a/src/CppReverse/UmlArtifact.cpp
+++ b/src/CppReverse/UmlArtifact.cpp
@@ -92,7 +92,7 @@ UmlArtifact * UmlArtifact::get_main()
     return main_art;
 }
 
-void UmlArtifact::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlArtifact::mark_useless(QList<UmlItem *> & l)
 {
     if (useless) {
         set_isMarked(TRUE);

--- a/src/CppReverse/UmlArtifact.h
+++ b/src/CppReverse/UmlArtifact.h
@@ -66,7 +66,7 @@ public:
     virtual bool set_roundtrip_expected();
     virtual void scan_it(int & n);
     virtual void send_it(int n);
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     bool set_roundtrip_expected_for_class();
     bool is_roundtrip_expected() const {
         return roundtrip_expected;

--- a/src/CppReverse/UmlAttribute.cpp
+++ b/src/CppReverse/UmlAttribute.cpp
@@ -94,7 +94,7 @@ bool UmlAttribute::new_one(Class * container, const WrapperStr & name,
                            const WrapperStr & bitfield, const WrapperStr & value,
                            WrapperStr comment, WrapperStr description
 #ifdef ROUNDTRIP
-                           , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                           , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                           )
 {

--- a/src/CppReverse/UmlAttribute.h
+++ b/src/CppReverse/UmlAttribute.h
@@ -49,7 +49,7 @@ public:
                         const WrapperStr & value,	WrapperStr comment,
                         WrapperStr description
 #ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                        );
 #ifdef ROUNDTRIP

--- a/src/CppReverse/UmlClass.cpp
+++ b/src/CppReverse/UmlClass.cpp
@@ -59,7 +59,7 @@ using namespace std;
 
 // contains the classes whose definition in currently read
 // may be more than one because of the nested classes
-Q3PtrList<UmlClass> UmlClass::UnderConstruction;
+QList<UmlClass *> UmlClass::UnderConstruction;
 
 // used (by using) classes list
 Q3Dict<UmlClass> UmlClass::Usings;
@@ -79,8 +79,8 @@ bool UmlClass::manage_inherit(ClassContainer * container,
 #ifdef REVERSE
                               , bool libp
 # ifdef ROUNDTRIP
-                              , bool roundtrip, Q3PtrList<UmlItem> & expected_order
-                              , bool container_roundtrip, Q3PtrList<UmlItem> & container_expected_order
+                              , bool roundtrip, QList<UmlItem *> & expected_order
+                              , bool container_roundtrip, QList<UmlItem *> & container_expected_order
 # endif
 #endif
                              )
@@ -291,7 +291,7 @@ UmlClass * UmlClass::auxilarily_typedef(const WrapperStr & base
                                         , bool libp
 # ifdef ROUNDTRIP
                                         , bool container_roundtrip
-                                        , Q3PtrList<UmlItem> & container_expected_order
+                                        , QList<UmlItem *> & container_expected_order
 # endif
 #endif
                                        )
@@ -467,12 +467,12 @@ void UmlClass::set_under_construction(bool y, bool rec)
     else if (rec)
         UnderConstruction.clear();
     else
-        UnderConstruction.removeRef(this);
+        UnderConstruction.removeOne(this);
 }
 
 bool UmlClass::inside_its_definition()
 {
-    return UnderConstruction.findRef(this) != -1;
+    return UnderConstruction.contains(this);
 }
 
 bool UmlClass::is_itself(WrapperStr t)
@@ -641,7 +641,7 @@ bool UmlClass::set_roundtrip_expected()
 
 }
 
-void UmlClass::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlClass::mark_useless(QList<UmlItem *> & l)
 {
     UmlClassItem::mark_useless(l);
 
@@ -733,7 +733,7 @@ UmlRelation * UmlClass::search_for_inherit(UmlClass * mother)
     return 0;
 }
 
-void UmlClass::reorder(Q3PtrList<UmlItem> & expected_order)
+void UmlClass::reorder(QList<UmlItem *> & expected_order)
 {
     if (expected_order.isEmpty())
         return;
@@ -745,10 +745,8 @@ void UmlClass::reorder(Q3PtrList<UmlItem> & expected_order)
 
     //bool updated = FALSE;
     UmlItem * expected_previous = 0;
-    Q3PtrListIterator<UmlItem> expected_it(expected_order);
-    UmlItem * expected;
 
-    while ((expected = expected_it.current()) != 0) {
+    foreach (UmlItem * expected, expected_order) {
         if (*v != expected) {
             //updated = TRUE;
             expected->moveAfter(expected_previous);
@@ -765,7 +763,6 @@ void UmlClass::reorder(Q3PtrList<UmlItem> & expected_order)
         }
 
         expected_previous = expected;
-        ++expected_it;
         v += 1;
     }
 

--- a/src/CppReverse/UmlClass.h
+++ b/src/CppReverse/UmlClass.h
@@ -60,8 +60,8 @@ public:
 #ifdef REVERSE
                         , bool libp
 # ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
-                        , bool container_roundtrip, Q3PtrList<UmlItem> & container_expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
+                        , bool container_roundtrip, QList<UmlItem *> & container_expected_order
 # endif
 #endif
                        );
@@ -97,7 +97,7 @@ public:
 # ifdef ROUNDTRIP
     virtual void upload(ClassContainer * cnt);
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
     bool is_created() const {
@@ -112,7 +112,7 @@ public:
     UmlItem * search_for_att_rel(const WrapperStr & name);
     UmlExtraClassMember * search_for_extra(const WrapperStr & name, const WrapperStr & decl);
     UmlRelation * search_for_inherit(UmlClass * mother);
-    void reorder(Q3PtrList<UmlItem> & expected_order);
+    void reorder(QList<UmlItem *> & expected_order);
 # endif
 #endif
 
@@ -122,12 +122,12 @@ private:
                                   , bool libp
 # ifdef ROUNDTRIP
                                   , bool container_roundtrip
-                                  , Q3PtrList<UmlItem> & container_expected_order
+                                  , QList<UmlItem *> & container_expected_order
 # endif
 #endif
                                  );
 
-    static Q3PtrList<UmlClass> UnderConstruction;
+    static QList<UmlClass *> UnderConstruction;
     static Q3Dict<UmlClass> Usings;
     static Q3ValueList<Q3Dict<UmlClass> > UsingScope;
 };

--- a/src/CppReverse/UmlClassItem.cpp
+++ b/src/CppReverse/UmlClassItem.cpp
@@ -41,7 +41,7 @@ bool UmlClassItem::set_roundtrip_expected()
     return isWritable();
 }
 
-void UmlClassItem::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlClassItem::mark_useless(QList<UmlItem *> & l)
 {
     if (is_useless()) {
         set_isMarked(TRUE);

--- a/src/CppReverse/UmlClassItem.h
+++ b/src/CppReverse/UmlClassItem.h
@@ -64,7 +64,7 @@ public:
         useless = !y;
     }
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
 # endif
 #endif
 };

--- a/src/CppReverse/UmlClassView.cpp
+++ b/src/CppReverse/UmlClassView.cpp
@@ -61,7 +61,7 @@ bool UmlClassView::set_roundtrip_expected()
     return result;
 }
 
-void UmlClassView::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlClassView::mark_useless(QList<UmlItem *> & l)
 {
     Q3PtrVector<UmlItem> ch = UmlItem::children();
     UmlClassItem ** v = (UmlClassItem **) ch.data();

--- a/src/CppReverse/UmlClassView.h
+++ b/src/CppReverse/UmlClassView.h
@@ -42,7 +42,7 @@ public:
 #ifdef ROUNDTRIP
     virtual void upload(ClassContainer *);
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
 #endif

--- a/src/CppReverse/UmlDeploymentView.cpp
+++ b/src/CppReverse/UmlDeploymentView.cpp
@@ -35,7 +35,7 @@
 //Added by qt3to4:
 #include <Q3PtrList>
 
-static Q3PtrList<UmlArtifact> Artifacts;
+static QList<UmlArtifact *> Artifacts;
 
 bool UmlDeploymentView::set_roundtrip_expected()
 {
@@ -50,7 +50,7 @@ bool UmlDeploymentView::set_roundtrip_expected()
     return result;
 }
 
-void UmlDeploymentView::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlDeploymentView::mark_useless(QList<UmlItem *> & l)
 {
     Q3PtrVector<UmlItem> ch = UmlItem::children();
     UmlClassItem ** v = (UmlClassItem **) ch.data();
@@ -80,15 +80,13 @@ void UmlDeploymentView::scan_it(int & n)
     if (n != 0) {
         Package::set_step(1, n);
 
-        Q3PtrListIterator<UmlArtifact> iter(Artifacts);
         Package * pk =
-            ((UmlPackage *) iter.current()->parent()->parent())->get_package();
+                ((UmlPackage *) Artifacts.first()->parent()->parent())->get_package();
 
-        do {
-            pk->reverse(iter.current());
+        foreach (UmlArtifact *artifact, Artifacts) {
+            pk->reverse(artifact);
             Progress::tic_it();
         }
-        while (++iter, iter.current() != 0);
 
 
         Package::set_step(1, -1);
@@ -100,15 +98,13 @@ void UmlDeploymentView::send_it(int n)
     if (n != 0) {
         Package::set_step(2, n);
 
-        Q3PtrListIterator<UmlArtifact> iter(Artifacts);
         Package * pk =
-            ((UmlPackage *) iter.current()->parent()->parent())->get_package();
+            ((UmlPackage *) Artifacts.first()->parent()->parent())->get_package();
 
-        do {
-            pk->reverse(iter.current());
+        foreach (UmlArtifact *artifact, Artifacts) {
+            pk->reverse(artifact);
             Progress::tic_it();
         }
-        while (++iter, iter.current() != 0);
 
 
         Package::set_step(2, -1);

--- a/src/CppReverse/UmlDeploymentView.h
+++ b/src/CppReverse/UmlDeploymentView.h
@@ -44,7 +44,7 @@ public:
 
 #ifdef ROUNDTRIP
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
 #endif

--- a/src/CppReverse/UmlItem.cpp
+++ b/src/CppReverse/UmlItem.cpp
@@ -47,7 +47,7 @@ bool UmlItem::set_roundtrip_expected()
     return TRUE;
 }
 
-void UmlItem::mark_useless(Q3PtrList<UmlItem> &)
+void UmlItem::mark_useless(QList<UmlItem *> &)
 {
     // does nothing
 }

--- a/src/CppReverse/UmlItem.h
+++ b/src/CppReverse/UmlItem.h
@@ -50,7 +50,7 @@ public:
 #ifdef ROUNDTRIP
     virtual void upload(ClassContainer *);
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
 #endif

--- a/src/CppReverse/UmlOperation.h
+++ b/src/CppReverse/UmlOperation.h
@@ -55,7 +55,7 @@ public:
                         bool friendp, WrapperStr friend_template,
                         WrapperStr comment, WrapperStr description, bool pfunc
 #ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                        );
     static void reverse_definition(Package * pack, WrapperStr name, WrapperStr type,
@@ -78,7 +78,7 @@ private:
 #ifdef ROUNDTRIP
     static Q3PtrDict<WrapperStr> DefNotYetSet;
 #endif
-    static NDict< Q3PtrList<UmlOperation> > friends;
+    static NDict< QList<UmlOperation *> > friends;
     FormalParameterList * formals;
     WrapperStr def0;	// for template operations
 
@@ -86,10 +86,10 @@ private:
                            UmlParameter & param, WrapperStr & decl,
                            const Q3ValueList<FormalParameterList> & tmplt,
                            BooL & on_error, bool add_defaultvalue);
-    static void friend_operations(Q3PtrList<UmlOperation> & candidates,
+    static void friend_operations(QList<UmlOperation *> & candidates,
                                   const Q3ValueList<FormalParameterList> & tmplt,
                                   const WrapperStr & name);
-    static bool operations(Q3PtrList<UmlOperation> & candidates, UmlClass * cl,
+    static bool operations(QList<UmlOperation *> & candidates, UmlClass * cl,
                            const Q3ValueList<FormalParameterList> & tmplt,
                            const FormalParameterList *& oper_tmplt,
                            const WrapperStr & name);

--- a/src/CppReverse/UmlPackage.cpp
+++ b/src/CppReverse/UmlPackage.cpp
@@ -341,7 +341,7 @@ bool UmlPackage::set_roundtrip_expected()
     return result;
 }
 
-void UmlPackage::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlPackage::mark_useless(QList<UmlItem *> & l)
 {
     Q3PtrVector<UmlItem> ch = UmlItem::children();
     UmlClassItem ** v = (UmlClassItem **) ch.data();

--- a/src/CppReverse/UmlPackage.h
+++ b/src/CppReverse/UmlPackage.h
@@ -55,7 +55,7 @@ public:
     void init(Package *);
     virtual void upload(ClassContainer *);
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
     Package * get_package() const {

--- a/src/CppReverse/UmlRelation.cpp
+++ b/src/CppReverse/UmlRelation.cpp
@@ -97,7 +97,7 @@ bool UmlRelation::new_one(Class * container, const WrapperStr & name,
                           const WrapperStr & value, WrapperStr comment,
                           WrapperStr description
 #ifdef ROUNDTRIP
-                          , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                          , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                          )
 {
@@ -356,7 +356,7 @@ bool UmlRelation::new_one(Class * container, const WrapperStr & name,
 #ifdef ROUNDTRIP
 
     bool UmlRelation::new_friend(Class * container, UmlClass * to,
-                                 Q3PtrList<UmlItem> & expected_order)
+                                 QList<UmlItem *> & expected_order)
     {
         UmlClass * from = container->get_uml();
 

--- a/src/CppReverse/UmlRelation.h
+++ b/src/CppReverse/UmlRelation.h
@@ -50,7 +50,7 @@ public:
                         const WrapperStr & value,	WrapperStr comment,
                         WrapperStr description
 #ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                        );
     static bool new_friend(UmlClass * from, UmlClass * to);
@@ -58,7 +58,7 @@ public:
 #ifdef ROUNDTRIP
     void set_unidir();
     static bool new_friend(Class * from, UmlClass * to,
-                           Q3PtrList<UmlItem> & expected_order);
+                           QList<UmlItem *> & expected_order);
 #endif
 };
 

--- a/src/CppRoundtrip/main.cpp
+++ b/src/CppRoundtrip/main.cpp
@@ -139,7 +139,7 @@ int main(int argc, char ** argv)
                     (*v)->set_isMarked(FALSE);
             }
 
-            Q3PtrList<UmlItem> useless;
+            QList<UmlItem *> useless;
 
             item->mark_useless(useless);
 
@@ -150,13 +150,10 @@ int main(int argc, char ** argv)
                                       "Delete them ?",
                                       "Yes", "No", QString(), 1, 1)
                  == 0)) {
-                Q3PtrListIterator<UmlItem> iter(useless);
-
-                do {
-                    if (iter.current()->isMarked())
-                        iter.current()->deleteIt();
+                foreach (UmlItem *item, useless) {
+                    if (item->isMarked())
+                        item->deleteIt();
                 }
-                while (++iter, iter.current() != 0);
             }
 
             project->set_childrenVisible(TRUE);

--- a/src/IdlGenerator/UmlArtifact.cpp
+++ b/src/IdlGenerator/UmlArtifact.cpp
@@ -101,7 +101,7 @@ void UmlArtifact::generate()
 #if 0
         // compute dependencies
 
-        Q3PtrList<CppRefType> dependencies;
+        QList<CppRefType *> dependencies;
 #endif
         const Q3PtrVector<UmlClass> & cls = associatedClasses();
         unsigned n = cls.count();

--- a/src/JavaCat/BrowserNode.cpp
+++ b/src/JavaCat/BrowserNode.cpp
@@ -83,8 +83,12 @@ void BrowserNodeList::search(BrowserNode * bn, int k,
     }
 }
 
-int BrowserNodeList::compareItems(Q3PtrCollection::Item item1, Q3PtrCollection::Item item2)
+bool BrowserNodeList::lessThan(BrowserNode *a, BrowserNode *b)
 {
-    return ((BrowserNode *) item1)->text(0)
-           .compare(((BrowserNode *) item2)->text(0));
+    return a->text(0) < b->text(0);
+}
+
+void BrowserNodeList::sort()
+{
+    qSort(begin(), end(), lessThan);
 }

--- a/src/JavaCat/BrowserNode.h
+++ b/src/JavaCat/BrowserNode.h
@@ -75,11 +75,12 @@ public:
 
 #include <q3ptrlist.h>
 
-class BrowserNodeList : public Q3PtrList<BrowserNode>
+class BrowserNodeList : public QList<BrowserNode *>
 {
 public:
     void search(BrowserNode * bn, int k, const QString & s, bool cs);
-    virtual int compareItems(Q3PtrCollection::Item item1, Q3PtrCollection::Item item2);
+    static bool lessThan(BrowserNode *a, BrowserNode *b);
+    void sort();
 };
 
 #endif

--- a/src/JavaCat/BrowserSearchDialog.cpp
+++ b/src/JavaCat/BrowserSearchDialog.cpp
@@ -131,9 +131,7 @@ void BrowserSearchDialog::search()
                  ed->text(), case_sensitive->isChecked());
     nodes.sort();
 
-    BrowserNode * bn;
-
-    for (bn = nodes.first(); bn != 0; bn = nodes.next()) {
+    foreach (BrowserNode *bn, nodes) {
         QString up = ((BrowserNode *) bn->parent())->get_path();
 
         results->insertItem((up.isEmpty())

--- a/src/JavaCat/Class.cpp
+++ b/src/JavaCat/Class.cpp
@@ -63,7 +63,39 @@ UmlArtifact * Class::CurrentArtifact;
 #include "Pixmap.h"
 #include "ShowFileDialog.h"
 
-Q3PtrList<Class> Class::Historic;
+HistoricList Class::Historic;
+
+void HistoricList::appendClass(Class *klass)
+{
+    while (current + 1 != Historic.size())
+        Historic.removeLast();
+
+    Historic.append(klass);
+    ++current;
+}
+
+bool HistoricList::hasPrev() const
+{
+    return current != 0;
+}
+
+Class *HistoricList::prev()
+{
+    --current;
+    return Historic[current];
+}
+
+bool HistoricList::hasNext() const
+{
+    return current + 1 < Historic.size();
+}
+
+Class *HistoricList::next()
+{
+    ++current;
+    return Historic[current];
+}
+
 #endif
 
 Class::Class(BrowserNode * p, const char * n, char st)
@@ -368,7 +400,7 @@ bool Class::reverse(ClassContainer * container, WrapperStr stereotype,
                     aVisibility visibility, WrapperStr & path,
                     Q3ValueList<FormalParameterList> tmplts
 #ifdef ROUNDTRIP
-                    , bool rndtrp, Q3PtrList<UmlItem> & expectedorder
+                    , bool rndtrp, QList<UmlItem *> & expectedorder
 #endif
                    )
 {
@@ -406,7 +438,7 @@ bool Class::reverse(ClassContainer * container, WrapperStr stereotype,
     }
 
     bool roundtrip = FALSE;
-    Q3PtrList<UmlItem> expected_order;
+    QList<UmlItem *> expected_order;
 #else
     UmlClass * cl_uml = 0;
 #endif
@@ -706,7 +738,7 @@ bool Class::reverse(ClassContainer * container, WrapperStr stereotype,
 bool Class::manage_extends(ClassContainer * container,
                            const Q3ValueList<FormalParameterList> & tmplts
 #ifdef ROUNDTRIP
-                           , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                           , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                           )
 {
@@ -747,7 +779,7 @@ bool Class::manage_extends(ClassContainer * container,
 bool Class::manage_implements(ClassContainer * container, aRelationKind k,
                               const Q3ValueList<FormalParameterList> & tmplts
 #ifdef ROUNDTRIP
-                              , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                              , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                              )
 {
@@ -804,7 +836,7 @@ bool Class::add_inherit(aRelationKind k, UmlTypeSpec & typespec,
                         Q3ValueList<UmlTypeSpec> & actuals,
                         WrapperStr & str_actuals
 #ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                        )
 {
@@ -1085,7 +1117,7 @@ bool Class::get_formals(FormalParameterList & tmplt, bool name_only,
 
 bool Class::manage_member(WrapperStr s, WrapperStr & path
 #ifdef ROUNDTRIP
-                          , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                          , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                          )
 {
@@ -1415,7 +1447,7 @@ bool Class::manage_member(WrapperStr s, WrapperStr & path
 
 bool Class::manage_enum_items(
 #ifdef ROUNDTRIP
-    bool roundtrip, Q3PtrList<UmlItem> & expected_order
+    bool roundtrip, QList<UmlItem *> & expected_order
 #endif
 )
 {
@@ -1613,10 +1645,7 @@ void Class::selected()
 void Class::manage_historic()
 {
     // manage historic
-    while (Historic.getLast() != Historic.current())
-        Historic.removeLast();
-
-    Historic.append(this);
+    Historic.appendClass(this);
 }
 
 // called when the node is activated for any reason
@@ -1743,13 +1772,13 @@ void Class::activated()
 
 void Class::historic_back()
 {
-    if (Historic.current() != Historic.getFirst())
+    if (Historic.hasPrev())
         BrowserView::select(Historic.prev());
 }
 
 void Class::historic_forward()
 {
-    if (Historic.current() != Historic.getLast())
+    if (Historic.hasNext())
         BrowserView::select(Historic.next());
 }
 

--- a/src/JavaCat/Class.h
+++ b/src/JavaCat/Class.h
@@ -46,6 +46,20 @@ class QPainter;
 class QColorGroup;
 #endif
 
+class Class;
+
+class HistoricList
+{
+    QList<Class *> Historic;
+    int current;
+public:
+    void appendClass(Class *klass);
+    bool hasPrev() const;
+    Class *prev();
+    bool hasNext() const;
+    Class *next();
+};
+
 class Class : public BrowserNode, public ClassContainer
 {
 protected:
@@ -66,7 +80,7 @@ protected:
     bool description_updatedp;
     WrapperStr description;
 
-    static Q3PtrList<Class> Historic;
+    static HistoricList Historic;
 #endif
     FormalParameterList formals;
 
@@ -75,31 +89,31 @@ protected:
     bool manage_extends(ClassContainer * container,
                         const Q3ValueList<FormalParameterList> & tmplts
 #ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                        );
     bool manage_implements(ClassContainer * container, aRelationKind k,
                            const Q3ValueList<FormalParameterList> & tmplts
 #ifdef ROUNDTRIP
-                           , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                           , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                           );
     bool add_inherit(aRelationKind k, UmlTypeSpec & typespec,
                      Q3ValueList<UmlTypeSpec> & actuals, WrapperStr & str_actual
 #ifdef ROUNDTRIP
-                     , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                     , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                     );
     void inherit(Class * cl);
     void inherit(UmlClass * uml_cl, WrapperStr header = 0);
     bool manage_member(WrapperStr s, WrapperStr & path
 #ifdef ROUNDTRIP
-                       , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                       , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                       );
     bool manage_enum_items(
 #ifdef ROUNDTRIP
-        bool roundtrip, Q3PtrList<UmlItem> & expected_order
+        bool roundtrip, QList<UmlItem *> & expected_order
 #endif
     );
     void set_description(const char * p);
@@ -174,7 +188,7 @@ public:
                         aVisibility visibility,	WrapperStr & f,
                         Q3ValueList<FormalParameterList> tmplts
 #ifdef ROUNDTRIP
-                        , bool rndtrp, Q3PtrList<UmlItem> & expectedorder
+                        , bool rndtrp, QList<UmlItem *> & expectedorder
 #endif
                        );
 

--- a/src/JavaCat/Package.cpp
+++ b/src/JavaCat/Package.cpp
@@ -325,9 +325,7 @@ int Package::count_file_number()
 
     QDir d(path);
     int result = file_number(d, TRUE);
-    TreeItem * child;
-
-    for (child = firstChild(); child != 0; child = child->nextSibling())
+    foreach (TreeItem *child, children())
         if (((BrowserNode *) child)->isa_package())
             result += ((Package *) child)->count_file_number();
 
@@ -351,9 +349,7 @@ void Package::scan_dir()
 
     reverse_directory(d, TRUE);
 
-    TreeItem * child;
-
-    for (child = firstChild(); child != 0; child = child->nextSibling())
+    foreach (TreeItem *child, children())
         if (((BrowserNode *) child)->isa_package())
             ((Package *) child)->scan_dir();
 }
@@ -539,9 +535,7 @@ void Package::send_dir()
 
     reverse_directory(d, TRUE);
 
-    TreeItem * child;
-
-    for (child = firstChild(); child != 0; child = child->nextSibling())
+    foreach (TreeItem *child, children())
         if (((BrowserNode *) child)->isa_package())
             ((Package *) child)->send_dir();
 }
@@ -811,7 +805,7 @@ void Package::reverse_file(WrapperStr f
                 if ((s == "class") || (s == "enum") ||
                     (s == "interface") || (s == "@interface")) {
 #ifdef ROUNDTRIP
-                    Q3PtrList<UmlItem> dummy;
+                    QList<UmlItem *> dummy;
 #endif
 
                     if (!Class::reverse(this, s, annotation, abstractp,
@@ -1251,9 +1245,13 @@ Package * Package::find(WrapperStr s, bool nohack)
     }
 
     Package * p = 0;
-    TreeItem * child;
 
-    for (child = firstChild(); child != 0; child = child->nextSibling()) {
+    // TODO: remove suspicious macro TreeItem in order to remove Qt3 dependency.
+#ifdef REVERSE
+    foreach (TreeItem * child,  children()) {
+#else
+    for (TreeItem *child = firstChild(); child; child = child->nextSibling()) {
+#endif
         if (((BrowserNode *) child)->isa_package() &&
             (child->text(0) == (const char *) name)) {
             p = (Package *) child;

--- a/src/JavaCat/TreeItem.h
+++ b/src/JavaCat/TreeItem.h
@@ -39,14 +39,14 @@
 
 #else
 
-#include <q3ptrlist.h>
-#include <qstring.h>
+#include <QList>
+#include <QString>
 
 class TreeItem
 {
 private:
     TreeItem * its_parent;
-    Q3PtrList<TreeItem> its_children;
+    QList<TreeItem *> its_children;
     QString its_name;	// java_classes share it in case of a java classes
 
 public:
@@ -62,12 +62,9 @@ public:
         return its_parent;
     };
 
-    TreeItem * firstChild() {
-        return its_children.first();
-    };
-    TreeItem * nextSibling() {
-        return its_parent->its_children.next();
-    };
+    const QList<TreeItem *> &children() const {
+        return its_children;
+    }
 };
 
 #endif

--- a/src/JavaCat/UmlArtifact.cpp
+++ b/src/JavaCat/UmlArtifact.cpp
@@ -82,7 +82,7 @@ bool UmlArtifact::is_roundtrip_usefull()
     return has_roundtrip_expected;
 }
 
-void UmlArtifact::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlArtifact::mark_useless(QList<UmlItem *> & l)
 {
     if (useless) {
         set_isMarked(TRUE);

--- a/src/JavaCat/UmlArtifact.h
+++ b/src/JavaCat/UmlArtifact.h
@@ -58,7 +58,7 @@ public:
     virtual bool set_roundtrip_expected();
     virtual void scan_it(int & n);
     virtual void send_it(int n);
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     bool set_roundtrip_expected_for_class();
     bool is_roundtrip_expected() const {
         return roundtrip_expected;

--- a/src/JavaCat/UmlAttribute.cpp
+++ b/src/JavaCat/UmlAttribute.cpp
@@ -94,7 +94,7 @@ bool UmlAttribute::new_one(Class * container, const WrapperStr & name,
                            const WrapperStr & value, WrapperStr comment,
                            WrapperStr description, WrapperStr annotation
 #ifdef ROUNDTRIP
-                           , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                           , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                           )
 {
@@ -341,7 +341,7 @@ bool UmlAttribute::new_one(Class * container, const WrapperStr & name,
     bool UmlAttribute::manage_enum_item(WrapperStr name, UmlClass * cl
 #ifdef ROUNDTRIP
                                         , bool roundtrip,
-                                        Q3PtrList<UmlItem> & expected_order
+                                        QList<UmlItem *> & expected_order
 #endif
                                        )
     {

--- a/src/JavaCat/UmlAttribute.h
+++ b/src/JavaCat/UmlAttribute.h
@@ -48,14 +48,14 @@ public:
                         const WrapperStr & value, WrapperStr comment,
                         WrapperStr description, WrapperStr annotation
 #ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                        );
 
     static bool manage_enum_item(WrapperStr s, UmlClass * cl
 #ifdef ROUNDTRIP
                                  , bool roundtrip,
-                                 Q3PtrList<UmlItem> & expected_order
+                                 QList<UmlItem *> & expected_order
 #endif
                                 );
 };

--- a/src/JavaCat/UmlClass.cpp
+++ b/src/JavaCat/UmlClass.cpp
@@ -145,7 +145,7 @@ bool UmlClass::set_roundtrip_expected()
 
 }
 
-void UmlClass::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlClass::mark_useless(QList<UmlItem *> & l)
 {
     UmlClassItem::mark_useless(l);
 
@@ -197,7 +197,7 @@ UmlItem * UmlClass::search_for_att_rel(const WrapperStr & name)
     return 0;
 }
 
-void UmlClass::reorder(Q3PtrList<UmlItem> & expected_order)
+void UmlClass::reorder(QList<UmlItem *> & expected_order)
 {
     if (expected_order.isEmpty())
         return;
@@ -209,10 +209,8 @@ void UmlClass::reorder(Q3PtrList<UmlItem> & expected_order)
 
     //bool updated = FALSE;
     UmlItem * expected_previous = 0;
-    Q3PtrListIterator<UmlItem> expected_it(expected_order);
-    UmlItem * expected;
 
-    while ((expected = expected_it.current()) != 0) {
+    foreach (UmlItem *expected, expected_order) {
         if (*v != expected) {
             //updated = TRUE;
             expected->moveAfter(expected_previous);
@@ -229,7 +227,6 @@ void UmlClass::reorder(Q3PtrList<UmlItem> & expected_order)
         }
 
         expected_previous = expected;
-        ++expected_it;
         v += 1;
     }
 

--- a/src/JavaCat/UmlClass.h
+++ b/src/JavaCat/UmlClass.h
@@ -60,7 +60,7 @@ public:
 # ifdef ROUNDTRIP
     virtual void upload(ClassContainer * cnt);
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
     bool is_created() const {
@@ -73,7 +73,7 @@ public:
         return the_class;
     }
     UmlItem * search_for_att_rel(const WrapperStr & name);
-    void reorder(Q3PtrList<UmlItem> & expected_order);
+    void reorder(QList<UmlItem *> & expected_order);
 # endif
 #endif
     static void manage_generic(WrapperStr & form, UmlTypeSpec & typespec,

--- a/src/JavaCat/UmlClassItem.cpp
+++ b/src/JavaCat/UmlClassItem.cpp
@@ -41,7 +41,7 @@ bool UmlClassItem::set_roundtrip_expected()
     return isWritable();
 }
 
-void UmlClassItem::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlClassItem::mark_useless(QList<UmlItem *> & l)
 {
     if (is_useless()) {
         set_isMarked(TRUE);

--- a/src/JavaCat/UmlClassItem.h
+++ b/src/JavaCat/UmlClassItem.h
@@ -61,7 +61,7 @@ public:
         useless = !y;
     }
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
 #endif
 };
 

--- a/src/JavaCat/UmlClassView.cpp
+++ b/src/JavaCat/UmlClassView.cpp
@@ -62,7 +62,7 @@ bool UmlClassView::set_roundtrip_expected()
     return result;
 }
 
-void UmlClassView::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlClassView::mark_useless(QList<UmlItem *> & l)
 {
     Q3PtrVector<UmlItem> ch = UmlItem::children();
     UmlClassItem ** v = (UmlClassItem **) ch.data();

--- a/src/JavaCat/UmlClassView.h
+++ b/src/JavaCat/UmlClassView.h
@@ -44,7 +44,7 @@ public:
 #ifdef ROUNDTRIP
     virtual void upload(ClassContainer *);
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
 #endif

--- a/src/JavaCat/UmlDeploymentView.cpp
+++ b/src/JavaCat/UmlDeploymentView.cpp
@@ -34,7 +34,7 @@
 //Added by qt3to4:
 #include <Q3PtrList>
 
-static Q3PtrList<UmlArtifact> Artifacts;
+static QList<UmlArtifact *> Artifacts;
 
 bool UmlDeploymentView::set_roundtrip_expected()
 {
@@ -49,7 +49,7 @@ bool UmlDeploymentView::set_roundtrip_expected()
     return result;
 }
 
-void UmlDeploymentView::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlDeploymentView::mark_useless(QList<UmlItem *> & l)
 {
     Q3PtrVector<UmlItem> ch = UmlItem::children();
     UmlClassItem ** v = (UmlClassItem **) ch.data();
@@ -79,15 +79,11 @@ void UmlDeploymentView::scan_it(int & n)
     if (n != 0) {
         Package::set_step(1, n);
 
-        Q3PtrListIterator<UmlArtifact> iter(Artifacts);
         Package * pk =
-            ((UmlPackage *) iter.current()->parent()->parent())->get_package();
+            ((UmlPackage *) Artifacts.first()->parent()->parent())->get_package();
 
-        do {
-            pk->reverse(iter.current());
-        }
-        while (++iter, iter.current() != 0);
-
+        foreach (UmlArtifact *artifact, Artifacts)
+            pk->reverse(artifact);
 
         Package::set_step(1, -1);
     }
@@ -98,14 +94,11 @@ void UmlDeploymentView::send_it(int n)
     if (n != 0) {
         Package::set_step(2, n);
 
-        Q3PtrListIterator<UmlArtifact> iter(Artifacts);
         Package * pk =
-            ((UmlPackage *) iter.current()->parent()->parent())->get_package();
+            ((UmlPackage *) Artifacts.first()->parent()->parent())->get_package();
 
-        do {
-            pk->reverse(iter.current());
-        }
-        while (++iter, iter.current() != 0);
+        foreach (UmlArtifact *artifact, Artifacts)
+            pk->reverse(artifact);
 
 
         Package::set_step(2, -1);

--- a/src/JavaCat/UmlDeploymentView.h
+++ b/src/JavaCat/UmlDeploymentView.h
@@ -44,7 +44,7 @@ public:
 
 #ifdef ROUNDTRIP
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
 #endif

--- a/src/JavaCat/UmlExtraClassMember.cpp
+++ b/src/JavaCat/UmlExtraClassMember.cpp
@@ -42,7 +42,7 @@
 //}
 
 void UmlExtraClassMember::add_init(UmlClass * cl, WrapperStr def, bool roundtrip,
-                                   Q3PtrList<UmlItem> & expected_order)
+                                   QList<UmlItem *> & expected_order)
 {
     if (roundtrip) {
         const Q3PtrVector<UmlItem> & ch = cl->children();

--- a/src/JavaCat/UmlExtraClassMember.h
+++ b/src/JavaCat/UmlExtraClassMember.h
@@ -51,7 +51,7 @@ public:
 
 #ifdef ROUNDTRIP
     static void add_init(UmlClass * cl, WrapperStr def, bool roundtrip,
-                         Q3PtrList<UmlItem> & expected_order);
+                         QList<UmlItem *> & expected_order);
 #endif
 };
 

--- a/src/JavaCat/UmlItem.cpp
+++ b/src/JavaCat/UmlItem.cpp
@@ -46,7 +46,7 @@ bool UmlItem::set_roundtrip_expected()
     return TRUE;
 }
 
-void UmlItem::mark_useless(Q3PtrList<UmlItem> &)
+void UmlItem::mark_useless(QList<UmlItem *> &)
 {
     // does nothing
 }

--- a/src/JavaCat/UmlItem.h
+++ b/src/JavaCat/UmlItem.h
@@ -50,7 +50,7 @@ public:
 #ifdef ROUNDTRIP
     virtual void upload(ClassContainer *);
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
 #endif

--- a/src/JavaCat/UmlOperation.cpp
+++ b/src/JavaCat/UmlOperation.cpp
@@ -66,7 +66,7 @@ bool UmlOperation::new_one(Class * container, const WrapperStr & name,
                            const WrapperStr & array, WrapperStr comment,
                            WrapperStr description, WrapperStr annotation
 #ifdef ROUNDTRIP
-                           , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                           , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                           )
 {
@@ -958,7 +958,7 @@ UmlOperation * UmlOperation::already_exist(Class * container, const WrapperStr &
     const Q3PtrVector<UmlItem> & ch = container->get_uml()->UmlItem::children();
     UmlItem ** v = ch.data();
     UmlItem ** const vsup = v + ch.size();
-    Q3PtrList<UmlOperation> opers;
+    QList<UmlOperation *> opers;
 
     for (; v != vsup; v += 1)
         if (((*v)->kind() == anOperation) &&
@@ -973,17 +973,16 @@ UmlOperation * UmlOperation::already_exist(Class * container, const WrapperStr &
     case 1:
         // suppose it is this one
         // even don't know if it is placed later in file
-        return opers.getFirst();
+        return opers.first();
 
     default:
         break;
     }
 
-    UmlOperation * op;
-    Q3PtrList<UmlOperation> same_names;
+    QList<UmlOperation *> same_names;
 
     // search for operation having the same params name and number
-    for (op = opers.first(); op != 0; op = opers.next()) {
+    foreach (UmlOperation *op, opers) {
         Q3ValueList<UmlParameter> ps = op->params();
         Q3ValueList<UmlParameter>::ConstIterator it1;
         Q3ValueList<UmlParameter>::ConstIterator it2;
@@ -1020,7 +1019,7 @@ UmlOperation * UmlOperation::already_exist(Class * container, const WrapperStr &
         // only one having the same number of param
         // and same param names (type changed)
         // suppose this one
-        return same_names.getFirst();
+        return same_names.first();
     }
 
     // suppose not find

--- a/src/JavaCat/UmlOperation.h
+++ b/src/JavaCat/UmlOperation.h
@@ -59,7 +59,7 @@ public:
                         const WrapperStr & array,	WrapperStr comment,
                         WrapperStr description, WrapperStr annotation
 #ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                        );
 

--- a/src/JavaCat/UmlPackage.cpp
+++ b/src/JavaCat/UmlPackage.cpp
@@ -189,7 +189,7 @@ bool UmlPackage::set_roundtrip_expected()
     return result;
 }
 
-void UmlPackage::mark_useless(Q3PtrList<UmlItem> & l)
+void UmlPackage::mark_useless(QList<UmlItem *> & l)
 {
     Q3PtrVector<UmlItem> ch = UmlItem::children();
     UmlClassItem ** v = (UmlClassItem **) ch.data();

--- a/src/JavaCat/UmlPackage.h
+++ b/src/JavaCat/UmlPackage.h
@@ -54,7 +54,7 @@ public:
     void init(Package *);
     virtual void upload(ClassContainer *);
     virtual bool set_roundtrip_expected();
-    virtual void mark_useless(Q3PtrList<UmlItem> & l);
+    virtual void mark_useless(QList<UmlItem *> & l);
     virtual void scan_it(int & n);
     virtual void send_it(int n);
     Package * get_package() const {

--- a/src/JavaCat/UmlRelation.cpp
+++ b/src/JavaCat/UmlRelation.cpp
@@ -98,7 +98,7 @@ bool UmlRelation::new_one(Class * container, const WrapperStr & name,
                           WrapperStr comment, WrapperStr description,
                           WrapperStr annotation
 #ifdef ROUNDTRIP
-                          , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                          , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                          )
 {
@@ -281,7 +281,7 @@ bool UmlRelation::new_one(Class * container, const WrapperStr & name,
                               WrapperStr comment, WrapperStr description,
                               WrapperStr annotation
 #ifdef ROUNDTRIP
-                              , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                              , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                              )
     {

--- a/src/JavaCat/UmlRelation.h
+++ b/src/JavaCat/UmlRelation.h
@@ -54,7 +54,7 @@ public:
                         WrapperStr comment, WrapperStr description,
                         WrapperStr annotation
 #ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                        );
     static bool new_one(Class * container, const WrapperStr & name,
@@ -66,7 +66,7 @@ public:
                         WrapperStr comment, WrapperStr description,
                         WrapperStr annotation
 #ifdef ROUNDTRIP
-                        , bool roundtrip, Q3PtrList<UmlItem> & expected_order
+                        , bool roundtrip, QList<UmlItem *> & expected_order
 #endif
                        );
 #ifdef ROUNDTRIP

--- a/src/JavaGenerator/UmlClassMember.cpp
+++ b/src/JavaGenerator/UmlClassMember.cpp
@@ -114,7 +114,7 @@ void UmlClassMember::generate_visibility(QTextStream & f, const char * parent_st
 }
 
 /*
-bool UmlClassMember::compute_dependency(Q3PtrList<JavaRefType> & dependencies,
+bool UmlClassMember::compute_dependency(QList<JavaRefType *> & dependencies,
 					WrapperStr decl, const UmlTypeSpec & t)
 {
   remove_comments(decl);

--- a/src/JavaGenerator/UmlExtraClassMember.cpp
+++ b/src/JavaGenerator/UmlExtraClassMember.cpp
@@ -33,7 +33,7 @@
 #include "UmlExtraClassMember.h"
 
 /*
-void UmlExtraClassMember::compute_dependency(Q3PtrList<JavaRefType> &, WrapperStr) {
+void UmlExtraClassMember::compute_dependency(QList<JavaRefType *> &, WrapperStr) {
   // does nothing
 }
 */

--- a/src/JavaRoundtrip/main.cpp
+++ b/src/JavaRoundtrip/main.cpp
@@ -201,7 +201,7 @@ int main(int argc, char ** argv)
                     (*v)->set_isMarked(FALSE);
             }
 
-            Q3PtrList<UmlItem> useless;
+            QList<UmlItem *> useless;
 
             item->mark_useless(useless);
 
@@ -212,13 +212,11 @@ int main(int argc, char ** argv)
                                       "Delete them ?",
                                       "Yes", "No", QString(), 1, 1)
                  == 0)) {
-                Q3PtrListIterator<UmlItem> iter(useless);
 
-                do {
-                    if (iter.current()->isMarked())
-                        iter.current()->deleteIt();
-                }
-                while (++iter, iter.current() != 0);
+                foreach (UmlItem *item, useless) {
+                    if (item->isMarked())
+                        item->deleteIt();
+                };
             }
 
             UmlPackage::getProject()->set_childrenVisible(TRUE);

--- a/src/PhpGenerator/UmlClassMember.cpp
+++ b/src/PhpGenerator/UmlClassMember.cpp
@@ -112,7 +112,7 @@ void UmlClassMember::generate_visibility(QTextStream & f)
 }
 
 /*
-bool UmlClassMember::compute_dependency(Q3PtrList<PhpRefType> & dependencies,
+bool UmlClassMember::compute_dependency(QList<PhpRefType *> & dependencies,
 					WrapperStr decl, const UmlTypeSpec & t)
 {
   remove_comments(decl);

--- a/src/PhpGenerator/UmlExtraClassMember.cpp
+++ b/src/PhpGenerator/UmlExtraClassMember.cpp
@@ -33,7 +33,7 @@
 #include "UmlExtraClassMember.h"
 
 /*
-void UmlExtraClassMember::compute_dependency(Q3PtrList<PhpRefType> &, WrapperStr) {
+void UmlExtraClassMember::compute_dependency(QList<PhpRefType *> &, WrapperStr) {
   // does nothing
 }
 */

--- a/src/PhpReverse/BrowserNode.h
+++ b/src/PhpReverse/BrowserNode.h
@@ -71,7 +71,7 @@ public:
 
 #include <q3ptrlist.h>
 
-class BrowserNodeList : public Q3PtrList<BrowserNode>
+class BrowserNodeList : public QList<BrowserNode *>
 {
 public:
     void search(BrowserNode * bn, int k, const QString & s, bool cs);

--- a/src/PhpReverse/Class.cpp
+++ b/src/PhpReverse/Class.cpp
@@ -64,7 +64,7 @@ using namespace std;
 #include "Pixmap.h"
 #include "ShowFileDialog.h"
 
-Q3PtrList<Class> Class::Historic;
+QList<Class *> Class::Historic;
 #endif
 
 Class::Class(Package * p, const char * n, char st)

--- a/src/PhpReverse/Class.h
+++ b/src/PhpReverse/Class.h
@@ -60,7 +60,7 @@ protected:
     bool description_updatedp;
     WrapperStr description;
 
-    static Q3PtrList<Class> Historic;
+    static QList<Class *> Historic;
 #endif
 
     bool manage_extends(ClassContainer * container);

--- a/src/PhpReverse/Package.cpp
+++ b/src/PhpReverse/Package.cpp
@@ -742,9 +742,8 @@ Package * Package::find(WrapperStr name, bool nohack)
         return this;
 
     Package * p = 0;
-    TreeItem * child;
 
-    for (child = firstChild(); child != 0; child = child->nextSibling()) {
+    foreach (TreeItem *child, children()) {
         if (((BrowserNode *) child)->isa_package() &&
             (child->text(0) == (const char *) name)) {
             p = (Package *) child;

--- a/src/PhpReverse/TreeItem.h
+++ b/src/PhpReverse/TreeItem.h
@@ -39,14 +39,14 @@
 
 #else
 
-#include <q3ptrlist.h>
-#include <qstring.h>
+#include <QList>
+#include <QString>
 
 class TreeItem
 {
 private:
     TreeItem * its_parent;
-    Q3PtrList<TreeItem> its_children;
+    QList<TreeItem *> its_children;
     QString its_name;
 
 public:
@@ -62,12 +62,9 @@ public:
         return its_parent;
     };
 
-    TreeItem * firstChild() {
-        return its_children.first();
-    };
-    TreeItem * nextSibling() {
-        return its_parent->its_children.next();
-    };
+    const QList<TreeItem *> &children() const {
+        return its_children;
+    }
 };
 
 #endif

--- a/src/ProjectControl/BrowserNode.h
+++ b/src/ProjectControl/BrowserNode.h
@@ -77,7 +77,7 @@ private:
 
 #include <q3ptrlist.h>
 
-class BrowserNodeList : public Q3PtrList<BrowserNode>
+class BrowserNodeList : public QList<BrowserNode *>
 {
 public:
     void search(BrowserNode * bn, const QString & s, bool cs);

--- a/src/ProjectSynchro/BrowserView.cpp
+++ b/src/ProjectSynchro/BrowserView.cpp
@@ -95,7 +95,7 @@ void BrowserView::select(Q3ListViewItem * b)
     if (!ongoing) {
         ongoing = TRUE;
 
-        const Q3PtrList<BrowserView> & l = SynchroWindow::get_browsers();
+        const QList<BrowserView *> & l = SynchroWindow::get_browsers();
         Q3PtrListIterator<BrowserView> it(l);
         QString fn = ((BrowserNode *) b)->file_name();
 
@@ -136,7 +136,7 @@ struct Use {
     Use(int rev) : rev_min(rev), rev_max(rev), count(1) {}
 };
 
-void BrowserView::update(const Q3PtrList<BrowserView> & lv)
+void BrowserView::update(const QList<BrowserView *> & lv)
 {
     Q3Dict<Use> all_nodes(DICT_SIZE);
     Q3PtrListIterator<BrowserView> itv(lv);
@@ -218,7 +218,7 @@ void BrowserView::update(const Q3PtrList<BrowserView> & lv)
 
     for (it = deleted_or_new.begin(); it != deleted_or_new.end(); ++it) {
         QString who = *it;
-        Q3PtrList<BrowserNode> images;
+        QList<BrowserNode *> images;
         bool young = FALSE;
 
         // set the state in each view without looking at the others

--- a/src/ProjectSynchro/BrowserView.h
+++ b/src/ProjectSynchro/BrowserView.h
@@ -77,7 +77,7 @@ public:
 
     void synchronize();
 
-    static void update(const Q3PtrList<BrowserView> &);
+    static void update(const QList<BrowserView *> &);
 
 protected:
     void update_it();

--- a/src/ProjectSynchro/SynchroDialog.cpp
+++ b/src/ProjectSynchro/SynchroDialog.cpp
@@ -39,7 +39,7 @@
 #include "SynchroDialog.h"
 #include "BrowserView.h"
 
-SynchroDialog::SynchroDialog(Q3PtrList<BrowserView> & b)
+SynchroDialog::SynchroDialog(QList<BrowserView *> & b)
     : QDialog(0, "Synchronize", TRUE), browsers(b)
 {
     setCaption("Synchronize");

--- a/src/ProjectSynchro/SynchroDialog.h
+++ b/src/ProjectSynchro/SynchroDialog.h
@@ -41,11 +41,11 @@ class SynchroDialog : public QDialog
     Q_OBJECT
 
 protected:
-    Q3PtrList<BrowserView> & browsers;
-    Q3PtrList<QCheckBox> checks;
+    QList<BrowserView *> & browsers;
+    QList<QCheckBox *> checks;
 
 public:
-    SynchroDialog(Q3PtrList<BrowserView> & b);
+    SynchroDialog(QList<BrowserView *> & b);
     virtual ~SynchroDialog();
 
 public slots:

--- a/src/ProjectSynchro/SynchroWindow.h
+++ b/src/ProjectSynchro/SynchroWindow.h
@@ -49,7 +49,7 @@ public:
 
     void load(int argc, char ** argv);
 
-    static const Q3PtrList<BrowserView> & get_browsers() {
+    static const QList<BrowserView *> & get_browsers() {
         return the->browsers;
     }
     static void abort();
@@ -58,7 +58,7 @@ protected:
     static SynchroWindow * the;
 
     QString project_name;
-    Q3PtrList<BrowserView> browsers;
+    QList<BrowserView *> browsers;
     Q3HBox * hbox;
 
     void load(QString path);

--- a/src/browser/BrowserActivity.cpp
+++ b/src/browser/BrowserActivity.cpp
@@ -142,7 +142,7 @@ void BrowserActivity::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserActivity::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserActivity::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -153,7 +153,7 @@ void BrowserActivity::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
 }
 
 // callers suppose this only take specification into acount
-void BrowserActivity::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserActivity::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserOperation * op)
 {
     IdIterator<BrowserActivity> it(all);
@@ -749,13 +749,11 @@ bool BrowserActivity::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-bool BrowserActivity::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserActivity::may_contains_them(const QList<BrowserNode *> & l,
                                         BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlInterruptibleActivityRegion:
         case UmlExpansionRegion:
         case UmlParameter:
@@ -771,16 +769,16 @@ bool BrowserActivity::may_contains_them(const Q3PtrList<BrowserNode> & l,
         case ForkAN:
         case JoinAN:
         case UmlDependOn:
-            return (((const BrowserNode *) it.current()->get_container(UmlActivity)) == this);
+            return (((const BrowserNode *) node->get_container(UmlActivity)) == this);
 
         default:
             return FALSE;
         }
 
-        if (! may_contains(it.current(), FALSE))
+        if (! may_contains(node, FALSE))
             return FALSE;
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserActivity.h
+++ b/src/browser/BrowserActivity.h
@@ -64,7 +64,7 @@ public:
     BrowserActivity(const BrowserActivity * model, BrowserNode * p);
     virtual ~BrowserActivity();
 
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> & l,
+    virtual bool may_contains_them(const QList<BrowserNode *> & l,
                                    BooL & duplicable) const;
     virtual BrowserNode * duplicate(BrowserNode * p,
                                     QString name = QString());
@@ -108,8 +108,8 @@ public:
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserOperation *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserOperation *);
 
     static void init();
     static const QStringList & default_stereotypes();

--- a/src/browser/BrowserActivityAction.cpp
+++ b/src/browser/BrowserActivityAction.cpp
@@ -137,7 +137,7 @@ void BrowserActivityAction::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserActivityAction::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserActivityAction::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserFlow::compute_referenced_by(l, this);
@@ -146,7 +146,7 @@ void BrowserActivityAction::referenced_by(Q3PtrList<BrowserNode> & l, bool ondel
         BrowserActivityDiagram::compute_referenced_by(l, this, "activityactioncanvas", "activityaction_ref");
 }
 
-void BrowserActivityAction::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserActivityAction::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * target)
 {
     IdIterator<BrowserActivityAction> it(all);
@@ -961,18 +961,16 @@ bool BrowserActivityAction::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-bool BrowserActivityAction::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserActivityAction::may_contains_them(const QList<BrowserNode *> & l,
         BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlParameterSet:
         case UmlActivityPin:
         case UmlFlow:
         case UmlDependOn:
-            if (((const BrowserNode *) it.current()->parent()) != this)
+            if (((const BrowserNode *) node->parent()) != this)
                 return FALSE;
 
             break;
@@ -981,10 +979,10 @@ bool BrowserActivityAction::may_contains_them(const Q3PtrList<BrowserNode> & l,
             return FALSE;
         }
 
-        if (! may_contains(it.current(), FALSE))
+        if (! may_contains(node, FALSE))
             return FALSE;
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserActivityAction.h
+++ b/src/browser/BrowserActivityAction.h
@@ -70,7 +70,7 @@ public:
 
     virtual BrowserNode * duplicate(BrowserNode * p,
                                     QString name = QString());
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> & l,
+    virtual bool may_contains_them(const QList<BrowserNode *> & l,
                                    BooL & duplicable) const;
     static BrowserActivityAction * add_activityaction(BrowserNode * future_parent,
             const char * s);
@@ -133,8 +133,8 @@ public:
     virtual void write_id(ToolCom * com);
     virtual bool api_compatible(unsigned v) const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserNode *);
 
     static void init();
     static const QStringList & default_stereotypes();

--- a/src/browser/BrowserActivityDiagram.cpp
+++ b/src/browser/BrowserActivityDiagram.cpp
@@ -55,7 +55,7 @@
 #include "mu.h"
 #include "translate.h"
 
-Q3PtrList<BrowserActivityDiagram> BrowserActivityDiagram::imported;
+QList<BrowserActivityDiagram *> BrowserActivityDiagram::imported;
 Q3ValueList<int> BrowserActivityDiagram::imported_ids;
 QStringList BrowserActivityDiagram::its_default_stereotypes;	// unicode
 
@@ -162,14 +162,12 @@ void BrowserActivityDiagram::import()
 {
     Q3ValueList<int>::Iterator it = imported_ids.begin();
 
-    while (!imported.isEmpty()) {
-        QString warning;
-        BrowserActivityDiagram * d = imported.take(0);
-
+    foreach (BrowserActivityDiagram *d, imported) {
         (new ActivityDiagramWindow(d->full_name(), d, *it))->close(TRUE);
         it = imported_ids.remove(it);
         d->is_modified = TRUE;
     }
+    imported.clear();
 }
 
 void BrowserActivityDiagram::renumber(int phase)
@@ -613,7 +611,7 @@ const QStringList & BrowserActivityDiagram::default_stereotypes()
     return its_default_stereotypes;
 }
 
-void BrowserActivityDiagram::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserActivityDiagram::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * bn,
         char const * kc,
         char const * kr)

--- a/src/browser/BrowserActivityDiagram.h
+++ b/src/browser/BrowserActivityDiagram.h
@@ -45,7 +45,7 @@ class BrowserActivityDiagram : public BrowserDiagram
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserActivityDiagram> imported;
+    static QList<BrowserActivityDiagram *> imported;
     static Q3ValueList<int> imported_ids;
     static QStringList its_default_stereotypes;
 
@@ -119,7 +119,7 @@ public:
     static void open_all();
     static void import();
 
-    static void compute_referenced_by(Q3PtrList<BrowserNode> & l, BrowserNode *,
+    static void compute_referenced_by(QList<BrowserNode *> & l, BrowserNode *,
                                       const char * kc, char const * kr);
 
     static QString drag_key(BrowserNode * p);

--- a/src/browser/BrowserActivityNode.cpp
+++ b/src/browser/BrowserActivityNode.cpp
@@ -121,7 +121,7 @@ void BrowserActivityNode::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserActivityNode::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserActivityNode::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserFlow::compute_referenced_by(l, this);
@@ -201,7 +201,7 @@ const QPixmap * BrowserActivityNode::pixmap(int) const
 
 bool BrowserActivityNode::target_of_flow() const
 {
-    Q3PtrList<BrowserNode> l;
+    QList<BrowserNode *> l;
 
     BrowserFlow::compute_referenced_by(l, this);
     return !l.isEmpty();

--- a/src/browser/BrowserActivityNode.h
+++ b/src/browser/BrowserActivityNode.h
@@ -98,7 +98,7 @@ public:
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
     bool target_of_flow() const;
 
     virtual bool allow_empty() const;

--- a/src/browser/BrowserActivityObject.cpp
+++ b/src/browser/BrowserActivityObject.cpp
@@ -121,7 +121,7 @@ void BrowserActivityObject::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserActivityObject::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserActivityObject::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserFlow::compute_referenced_by(l, this);
@@ -130,7 +130,7 @@ void BrowserActivityObject::referenced_by(Q3PtrList<BrowserNode> & l, bool ondel
         BrowserActivityDiagram::compute_referenced_by(l, this, "activityobjectcanvas", "activityobject_ref");
 }
 
-void BrowserActivityObject::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserActivityObject::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * target)
 {
     IdIterator<BrowserActivityObject> it(all);
@@ -609,25 +609,23 @@ bool BrowserActivityObject::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-bool BrowserActivityObject::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserActivityObject::may_contains_them(const QList<BrowserNode *> & l,
         BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlFlow:
         case UmlDependOn:
-            return (((const BrowserNode *) it.current()->parent()) == this);
+            return (((const BrowserNode *) node->parent()) == this);
 
         default:
             return FALSE;
         }
 
-        if (! may_contains(it.current(), FALSE))
+        if (! may_contains(node, FALSE))
             return FALSE;
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserActivityObject.h
+++ b/src/browser/BrowserActivityObject.h
@@ -66,7 +66,7 @@ public:
 
     virtual BrowserNode * duplicate(BrowserNode * p,
                                     QString name = QString());
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> & l,
+    virtual bool may_contains_them(const QList<BrowserNode *> & l,
                                    BooL & duplicable) const;
     static BrowserActivityObject * add_activityobject(BrowserNode * future_parent,
             const char * s);
@@ -109,8 +109,8 @@ public:
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserNode *);
 
     static void init();
     static const QStringList & default_stereotypes();

--- a/src/browser/BrowserActivityPartition.cpp
+++ b/src/browser/BrowserActivityPartition.cpp
@@ -123,7 +123,7 @@ void BrowserActivityPartition::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserActivityPartition::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserActivityPartition::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -510,25 +510,23 @@ bool BrowserActivityPartition::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-bool BrowserActivityPartition::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserActivityPartition::may_contains_them(const QList<BrowserNode *> & l,
         BooL & duplicable) const
 {
     BrowserNode * activity = get_container(UmlActivity);
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlActivityPartition:
-            return (((const BrowserNode *) it.current()->get_container(UmlActivity)) == activity);
+            return (((const BrowserNode *) node->get_container(UmlActivity)) == activity);
 
         default:
             return FALSE;
         }
 
-        if (! may_contains(it.current(), FALSE))
+        if (! may_contains(node, FALSE))
             return FALSE;
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserActivityPartition.h
+++ b/src/browser/BrowserActivityPartition.h
@@ -62,7 +62,7 @@ public:
     BrowserActivityPartition(const BrowserActivityPartition * model, BrowserNode * p);
     virtual ~BrowserActivityPartition();
 
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> & l,
+    virtual bool may_contains_them(const QList<BrowserNode *> & l,
                                    BooL & duplicable) const;
     virtual BrowserNode * duplicate(BrowserNode * p,
                                     QString name = QString());
@@ -94,7 +94,7 @@ public:
     static BrowserNode * get_it(const char * k, int id);
     static void post_load();
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
 
     static void clear(bool old);
     static void update_idmax_for_root();

--- a/src/browser/BrowserArtifact.cpp
+++ b/src/browser/BrowserArtifact.cpp
@@ -151,7 +151,7 @@ void BrowserArtifact::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserArtifact::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserArtifact::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     compute_referenced_by(l, this);
@@ -160,7 +160,7 @@ void BrowserArtifact::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
         BrowserDeploymentDiagram::compute_referenced_by(l, this, "artifactcanvas", "artifact_ref");
 }
 
-void BrowserArtifact::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserArtifact::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserClass * target)
 {
     IdIterator<BrowserArtifact> it(all);
@@ -175,7 +175,7 @@ void BrowserArtifact::compute_referenced_by(Q3PtrList<BrowserNode> & l,
     }
 }
 
-void BrowserArtifact::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserArtifact::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserArtifact * target)
 {
     IdIterator<BrowserArtifact> it(all);

--- a/src/browser/BrowserArtifact.h
+++ b/src/browser/BrowserArtifact.h
@@ -121,9 +121,9 @@ public:
     virtual const QPixmap * pixmap(int) const;
     virtual void iconChanged();
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserArtifact *);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserClass *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserArtifact *);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserClass *);
 
     static void init();
     static const QStringList & default_stereotypes();

--- a/src/browser/BrowserAttribute.cpp
+++ b/src/browser/BrowserAttribute.cpp
@@ -534,7 +534,7 @@ void BrowserAttribute::member_cpp_def(const QString & prefix, const QString &,
     }
 }
 
-void BrowserAttribute::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserAttribute::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * target)
 {
     IdIterator<BrowserAttribute> it(all);
@@ -551,7 +551,7 @@ void BrowserAttribute::compute_referenced_by(Q3PtrList<BrowserNode> & l,
     }
 }
 
-void BrowserAttribute::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserAttribute::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 

--- a/src/browser/BrowserAttribute.h
+++ b/src/browser/BrowserAttribute.h
@@ -114,8 +114,8 @@ public:
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserNode *);
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
 

--- a/src/browser/BrowserClass.h
+++ b/src/browser/BrowserClass.h
@@ -70,7 +70,7 @@ protected:
 
 protected:
 
-    void exec_menu_choice(int index, Q3PtrList<BrowserOperation> & l);
+    void exec_menu_choice(int index, QList<BrowserOperation *> & l);
 
 public:
     BrowserClass(QString s, BrowserNode * p, ClassData * d, int id = 0);
@@ -87,12 +87,12 @@ public:
     BrowserNode * addOperation(BrowserOperation * oper = nullptr);
     BrowserNode * add_inherited_operation(BrowserOperation * model);
     BrowserNode * add_extra_member(BrowserExtraMember * em = 0);
-    Q3PtrList<BrowserOperation> inherited_operations(unsigned limit, QString parent_name = QString()) const;
+    QList<BrowserOperation *> inherited_operations(unsigned limit, QString parent_name = QString()) const;
     QString may_start(UmlCode l) const;
     QString may_connect(UmlCode l, BrowserClass * other);
     virtual BasicData * add_relation(UmlCode, BrowserNode *);
-    virtual Q3PtrList<BrowserNode> parents() const;
-    void get_all_parents(Q3PtrList<BrowserClass> &) const;
+    virtual QList<BrowserNode *> parents() const;
+    void get_all_parents(QList<BrowserClass *> &) const;
     // more modern interface to get all parents. Still a lot of qt3 compatibility inside
     QList<BrowserClass*> get_all_parents();
     QStringList get_parents_names();
@@ -111,9 +111,9 @@ public:
 
 
 
-    void get_attrs(BrowserNodeList &) const;
-    void get_rels(BrowserClass *, Q3PtrList<RelationData> &, int * rev = 0) const;
-    void get_rels(BrowserClass * target, Q3PtrList<BrowserRelation> & l) const;
+    void get_attrs(BrowserNodeList &);
+    void get_rels(BrowserClass *, QList<RelationData *> &, int * rev = 0) const;
+    void get_rels(BrowserClass * target, QList<BrowserRelation *> & l) const;
     void get_tree(BrowserNodeList &);
     virtual BrowserNode * get_associated() const;
     void set_associated_diagram(BrowserClassDiagram *, bool on_read = FALSE);
@@ -125,7 +125,7 @@ public:
 
     virtual void delete_it();
     virtual bool undelete(bool rec, QString & warning, QString & renamed);
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> &,
+    virtual bool may_contains_them(const QList<BrowserNode *> &,
                                    BooL & duplicable) const;
     virtual void move(BrowserNode *, BrowserNode * after);
     virtual BrowserNode * duplicate(BrowserNode * p,
@@ -185,7 +185,7 @@ public:
     static void read_stereotypes(char *& , char *&);
     static void save_stereotypes(QTextStream &);
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
 
     static bool new_java_enums(QString new_st);
 

--- a/src/browser/BrowserClassDiagram.cpp
+++ b/src/browser/BrowserClassDiagram.cpp
@@ -54,7 +54,7 @@
 #include "mu.h"
 #include "translate.h"
 
-Q3PtrList<BrowserClassDiagram> BrowserClassDiagram::imported;
+QList<BrowserClassDiagram *> BrowserClassDiagram::imported;
 Q3ValueList<int> BrowserClassDiagram::imported_ids;
 QStringList BrowserClassDiagram::its_default_stereotypes;	// unicode
 
@@ -148,14 +148,12 @@ void BrowserClassDiagram::import()
 {
     Q3ValueList<int>::Iterator it = imported_ids.begin();
 
-    while (!imported.isEmpty()) {
-        QString warning;
-        BrowserClassDiagram * d = imported.take(0);
-
+    foreach (BrowserClassDiagram *d, imported) {
         (new ClassDiagramWindow(d->full_name(), d, *it))->close(TRUE);
         it = imported_ids.remove(it);
         d->is_modified = TRUE;
     }
+    imported.clear();
 }
 
 void BrowserClassDiagram::renumber(int phase)
@@ -531,7 +529,7 @@ bool BrowserClassDiagram::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-void BrowserClassDiagram::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserClassDiagram::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * bn,
         char const * kc,
         char const * kr)

--- a/src/browser/BrowserClassDiagram.h
+++ b/src/browser/BrowserClassDiagram.h
@@ -45,7 +45,7 @@ class BrowserClassDiagram : public BrowserDiagram
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserClassDiagram> imported;
+    static QList<BrowserClassDiagram *> imported;
     static Q3ValueList<int> imported_ids;
     static QStringList its_default_stereotypes;
 
@@ -113,7 +113,7 @@ public:
     static void open_all();
     static void import();
 
-    static void compute_referenced_by(Q3PtrList<BrowserNode> & l, BrowserNode *,
+    static void compute_referenced_by(QList<BrowserNode *> & l, BrowserNode *,
                                       const char * kc, char const * kr);
 };
 

--- a/src/browser/BrowserClassInstance.cpp
+++ b/src/browser/BrowserClassInstance.cpp
@@ -208,7 +208,7 @@ void BrowserClassInstance::update_stereotype(bool)
     }
 }
 
-void BrowserClassInstance::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserClassInstance::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserClassInstance::compute_referenced_by(l, this);
@@ -220,7 +220,7 @@ void BrowserClassInstance::referenced_by(Q3PtrList<BrowserNode> & l, bool ondele
     }
 }
 
-void BrowserClassInstance::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserClassInstance::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * target)
 {
     IdIterator<BrowserClassInstance> it(all);

--- a/src/browser/BrowserClassInstance.h
+++ b/src/browser/BrowserClassInstance.h
@@ -93,8 +93,8 @@ public:
     virtual bool api_compatible(unsigned v) const;
     static void add_from_tool(BrowserNode * parent, ToolCom * com, const char * args);
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserNode *);
 
     static BrowserNodeList & instances(BrowserNodeList &, const char * st = 0);
     static BrowserClassInstance * get_classinstance(BrowserNode * future_parent);

--- a/src/browser/BrowserClassView.cpp
+++ b/src/browser/BrowserClassView.cpp
@@ -980,13 +980,11 @@ void BrowserClassView::DragMoveInsideEvent(QDragMoveEvent * e)
         e->ignore();
 }
 
-bool BrowserClassView::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserClassView::may_contains_them(const QList<BrowserNode *> & l,
         BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *current, l) {
+        switch (current->get_type()) {
         case UmlClass:
         case UmlClassInstance:
         case UmlClassDiagram:
@@ -995,7 +993,7 @@ bool BrowserClassView::may_contains_them(const Q3PtrList<BrowserNode> & l,
         case UmlObjectDiagram:
         case UmlState:
         case UmlActivity:
-            if (! may_contains(it.current(), FALSE))
+            if (! may_contains(current, FALSE))
                 return FALSE;
 
             break;
@@ -1004,7 +1002,7 @@ bool BrowserClassView::may_contains_them(const Q3PtrList<BrowserNode> & l,
             return FALSE;
         }
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(current);
     }
 
     return TRUE;

--- a/src/browser/BrowserClassView.h
+++ b/src/browser/BrowserClassView.h
@@ -97,7 +97,7 @@ public:
     virtual QString get_stype() const;
     virtual int get_identifier() const;
     virtual const char * help_topic() const;
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> &,
+    virtual bool may_contains_them(const QList<BrowserNode *> &,
                                    BooL & duplicable) const;
     virtual BrowserNode * container(UmlCode) const; // container for class, state machine and activity
     virtual BasicData * get_data() const;

--- a/src/browser/BrowserColDiagram.cpp
+++ b/src/browser/BrowserColDiagram.cpp
@@ -53,7 +53,7 @@
 #include "mu.h"
 #include "translate.h"
 
-Q3PtrList<BrowserColDiagram> BrowserColDiagram::imported;
+QList<BrowserColDiagram *> BrowserColDiagram::imported;
 Q3ValueList<int> BrowserColDiagram::imported_ids;
 QStringList BrowserColDiagram::its_default_stereotypes;	// unicode
 
@@ -147,14 +147,12 @@ void BrowserColDiagram::import()
 {
     Q3ValueList<int>::Iterator it = imported_ids.begin();
 
-    while (!imported.isEmpty()) {
-        QString warning;
-        BrowserColDiagram * d = imported.take(0);
-
+    foreach (BrowserColDiagram *d, imported) {
         (new ColDiagramWindow(d->full_name(), d, *it))->close(TRUE);
         it = imported_ids.remove(it);
         d->is_modified = TRUE;
     }
+    imported.clear();
 }
 
 void BrowserColDiagram::renumber(int phase)
@@ -554,7 +552,7 @@ bool BrowserColDiagram::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-void BrowserColDiagram::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserColDiagram::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * bn,
         char const * kc,
         char const * kr)

--- a/src/browser/BrowserColDiagram.h
+++ b/src/browser/BrowserColDiagram.h
@@ -44,7 +44,7 @@ class BrowserColDiagram : public BrowserDiagram
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserColDiagram> imported;
+    static QList<BrowserColDiagram *> imported;
     static Q3ValueList<int> imported_ids;
     static QStringList its_default_stereotypes;
 
@@ -112,7 +112,7 @@ public:
     static void open_all();
     static void import();
 
-    static void compute_referenced_by(Q3PtrList<BrowserNode> & l, BrowserNode *,
+    static void compute_referenced_by(QList<BrowserNode *> & l, BrowserNode *,
                                       const char * kc, char const * kr);
 };
 

--- a/src/browser/BrowserComponent.cpp
+++ b/src/browser/BrowserComponent.cpp
@@ -130,7 +130,7 @@ void BrowserComponent::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserComponent::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserComponent::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -140,7 +140,7 @@ void BrowserComponent::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
     }
 }
 
-void BrowserComponent::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserComponent::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserClass * target)
 {
     IdIterator<BrowserComponent> it(all);
@@ -783,8 +783,8 @@ void BrowserComponent::get_all_provided_classes(Q3ValueList<BrowserClass *> & r,
         r.clear();
         nl.sort_it();
 
-        while (! nl.isEmpty())
-            r.append((BrowserClass *) nl.take(0));
+        foreach (BrowserNode *node, nl)
+            r.append((BrowserClass *) node);
     }
 }
 
@@ -824,8 +824,8 @@ void BrowserComponent::get_all_required_classes(Q3ValueList<BrowserClass *> & r,
         r.clear();
         nl.sort_it();
 
-        while (! nl.isEmpty())
-            r.append((BrowserClass *) nl.take(0));
+        foreach (BrowserNode *node, nl)
+            r.append((BrowserClass *) node);
     }
 }
 

--- a/src/browser/BrowserComponent.h
+++ b/src/browser/BrowserComponent.h
@@ -124,8 +124,8 @@ public:
     virtual const QPixmap * pixmap(int) const;
     virtual void iconChanged();
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserClass *);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserClass *);
 
     static void init();
     static const QStringList & default_stereotypes();

--- a/src/browser/BrowserComponentDiagram.cpp
+++ b/src/browser/BrowserComponentDiagram.cpp
@@ -54,7 +54,7 @@
 #include "mu.h"
 #include "translate.h"
 
-Q3PtrList<BrowserComponentDiagram> BrowserComponentDiagram::imported;
+QList<BrowserComponentDiagram *> BrowserComponentDiagram::imported;
 Q3ValueList<int> BrowserComponentDiagram::imported_ids;
 QStringList BrowserComponentDiagram::its_default_stereotypes;	// unicode
 
@@ -148,14 +148,12 @@ void BrowserComponentDiagram::import()
 {
     Q3ValueList<int>::Iterator it = imported_ids.begin();
 
-    while (!imported.isEmpty()) {
-        QString warning;
-        BrowserComponentDiagram * d = imported.take(0);
-
+    foreach (BrowserComponentDiagram *d, imported) {
         (new ComponentDiagramWindow(d->full_name(), d, *it))->close(TRUE);
         it = imported_ids.remove(it);
         d->is_modified = TRUE;
     }
+    imported.clear();
 }
 
 void BrowserComponentDiagram::renumber(int phase)
@@ -536,7 +534,7 @@ bool BrowserComponentDiagram::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-void BrowserComponentDiagram::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserComponentDiagram::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * bn,
         char const * kc,
         char const * kr)

--- a/src/browser/BrowserComponentDiagram.h
+++ b/src/browser/BrowserComponentDiagram.h
@@ -44,7 +44,7 @@ class BrowserComponentDiagram : public BrowserDiagram
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserComponentDiagram> imported;
+    static QList<BrowserComponentDiagram *> imported;
     static Q3ValueList<int> imported_ids;
     static QStringList its_default_stereotypes;
 
@@ -112,7 +112,7 @@ public:
     static void open_all();
     static void import();
 
-    static void compute_referenced_by(Q3PtrList<BrowserNode> & l, BrowserNode *,
+    static void compute_referenced_by(QList<BrowserNode *> & l, BrowserNode *,
                                       const char * kc, char const * kr);
 };
 

--- a/src/browser/BrowserComponentView.cpp
+++ b/src/browser/BrowserComponentView.cpp
@@ -510,19 +510,17 @@ void BrowserComponentView::DragMoveInsideEvent(QDragMoveEvent * e)
         e->ignore();
 }
 
-bool BrowserComponentView::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserComponentView::may_contains_them(const QList<BrowserNode *> & l,
         BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlComponent:
             duplicable = FALSE;
 
             // no break
         case UmlComponentDiagram:
-            if (! may_contains(it.current(), FALSE))
+            if (! may_contains(node, FALSE))
                 return FALSE;
 
             break;
@@ -531,7 +529,7 @@ bool BrowserComponentView::may_contains_them(const Q3PtrList<BrowserNode> & l,
             return FALSE;
         }
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserComponentView.h
+++ b/src/browser/BrowserComponentView.h
@@ -79,7 +79,7 @@ public:
     virtual QString get_stype() const;
     virtual int get_identifier() const;
     virtual const char * help_topic() const;
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> &,
+    virtual bool may_contains_them(const QList<BrowserNode *> &,
                                    BooL & duplicable) const;
     virtual BasicData * get_data() const;
     virtual void get_componentdiagramsettings(ComponentDiagramSettings &) const;

--- a/src/browser/BrowserDeploymentDiagram.cpp
+++ b/src/browser/BrowserDeploymentDiagram.cpp
@@ -54,7 +54,7 @@
 #include "mu.h"
 #include "translate.h"
 
-Q3PtrList<BrowserDeploymentDiagram> BrowserDeploymentDiagram::imported;
+QList<BrowserDeploymentDiagram *> BrowserDeploymentDiagram::imported;
 Q3ValueList<int> BrowserDeploymentDiagram::imported_ids;
 QStringList BrowserDeploymentDiagram::its_default_stereotypes;	// unicode
 
@@ -152,14 +152,12 @@ void BrowserDeploymentDiagram::import()
 {
     Q3ValueList<int>::Iterator it = imported_ids.begin();
 
-    while (!imported.isEmpty()) {
-        QString warning;
-        BrowserDeploymentDiagram * d = imported.take(0);
-
+    foreach (BrowserDeploymentDiagram *d, imported) {
         (new DeploymentDiagramWindow(d->full_name(), d, *it))->close(TRUE);
         it = imported_ids.remove(it);
         d->is_modified = TRUE;
     }
+    imported.clear();
 }
 
 void BrowserDeploymentDiagram::renumber(int phase)
@@ -549,7 +547,7 @@ bool BrowserDeploymentDiagram::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-void BrowserDeploymentDiagram::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserDeploymentDiagram::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * bn,
         char const * kc,
         char const * kr)

--- a/src/browser/BrowserDeploymentDiagram.h
+++ b/src/browser/BrowserDeploymentDiagram.h
@@ -44,7 +44,7 @@ class BrowserDeploymentDiagram : public BrowserDiagram
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserDeploymentDiagram> imported;
+    static QList<BrowserDeploymentDiagram *> imported;
     static Q3ValueList<int> imported_ids;
     static QStringList its_default_stereotypes;
 
@@ -114,7 +114,7 @@ public:
     static void open_all();
     static void import();
 
-    static void compute_referenced_by(Q3PtrList<BrowserNode> & l, BrowserNode *,
+    static void compute_referenced_by(QList<BrowserNode *> & l, BrowserNode *,
                                       const char * kc, char const * kr);
 };
 

--- a/src/browser/BrowserDeploymentNode.cpp
+++ b/src/browser/BrowserDeploymentNode.cpp
@@ -120,7 +120,7 @@ void BrowserDeploymentNode::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserDeploymentNode::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserDeploymentNode::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 

--- a/src/browser/BrowserDeploymentNode.h
+++ b/src/browser/BrowserDeploymentNode.h
@@ -92,7 +92,7 @@ public:
     static void update_idmax_for_root();
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
 
     virtual const QPixmap * pixmap(int) const;
     virtual void iconChanged();

--- a/src/browser/BrowserDeploymentView.cpp
+++ b/src/browser/BrowserDeploymentView.cpp
@@ -707,20 +707,18 @@ void BrowserDeploymentView::DragMoveInsideEvent(QDragMoveEvent * e)
         e->ignore();
 }
 
-bool BrowserDeploymentView::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserDeploymentView::may_contains_them(const QList<BrowserNode *> & l,
         BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlArtifact:
             duplicable = FALSE;
 
             // no break
         case UmlDeploymentNode:
         case UmlDeploymentDiagram:
-            if (! may_contains(it.current(), FALSE))
+            if (! may_contains(node, FALSE))
                 return FALSE;
 
             break;
@@ -729,7 +727,7 @@ bool BrowserDeploymentView::may_contains_them(const Q3PtrList<BrowserNode> & l,
             return FALSE;
         }
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserDeploymentView.h
+++ b/src/browser/BrowserDeploymentView.h
@@ -80,7 +80,7 @@ public:
     virtual QString get_stype() const;
     virtual int get_identifier() const;
     virtual const char * help_topic() const;
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> &,
+    virtual bool may_contains_them(const QList<BrowserNode *> &,
                                    BooL & duplicable) const;
     virtual BasicData * get_data() const;
     virtual void get_deploymentdiagramsettings(DeploymentDiagramSettings &) const;

--- a/src/browser/BrowserExpansionNode.cpp
+++ b/src/browser/BrowserExpansionNode.cpp
@@ -366,7 +366,7 @@ QString BrowserExpansionNode::full_name(bool rev, bool) const
     return fullname(s, rev);
 }
 
-void BrowserExpansionNode::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserExpansionNode::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserFlow::compute_referenced_by(l, this);
@@ -375,7 +375,7 @@ void BrowserExpansionNode::referenced_by(Q3PtrList<BrowserNode> & l, bool ondele
         BrowserActivityDiagram::compute_referenced_by(l, this, "expansionnodecanvas", "expansionnode_ref");
 }
 
-void BrowserExpansionNode::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserExpansionNode::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * target)
 {
     IdIterator<BrowserExpansionNode> it(all);

--- a/src/browser/BrowserExpansionNode.h
+++ b/src/browser/BrowserExpansionNode.h
@@ -96,8 +96,8 @@ public:
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserNode *);
 
     virtual void DropAfterEvent(QDropEvent * e, BrowserNode * after);
     QString drag_key() const;

--- a/src/browser/BrowserExpansionRegion.cpp
+++ b/src/browser/BrowserExpansionRegion.cpp
@@ -126,7 +126,7 @@ void BrowserExpansionRegion::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserExpansionRegion::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserExpansionRegion::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -619,17 +619,16 @@ bool BrowserExpansionRegion::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-bool BrowserExpansionRegion::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserExpansionRegion::may_contains_them(const QList<BrowserNode *> & l,
         BooL & duplicable) const
 {
     BrowserNode * activity = get_container(UmlActivity);
-    Q3PtrListIterator<BrowserNode> it(l);
 
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlInterruptibleActivityRegion:
         case UmlExpansionRegion:
-            if (((const BrowserNode *) it.current()->get_container(UmlActivity)) != activity)
+            if (((const BrowserNode *) node->get_container(UmlActivity)) != activity)
                 return FALSE;
 
             break;
@@ -644,7 +643,7 @@ bool BrowserExpansionRegion::may_contains_them(const Q3PtrList<BrowserNode> & l,
         case MergeAN:
         case ForkAN:
         case JoinAN:
-            if (((const BrowserNode *) it.current()->get_container(UmlActivity)) != activity)
+            if (((const BrowserNode *) node->get_container(UmlActivity)) != activity)
                 return FALSE;
 
             break;
@@ -653,10 +652,10 @@ bool BrowserExpansionRegion::may_contains_them(const Q3PtrList<BrowserNode> & l,
             return FALSE;
         }
 
-        if (! may_contains(it.current(), TRUE))
+        if (! may_contains(node, TRUE))
             return FALSE;
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserExpansionRegion.h
+++ b/src/browser/BrowserExpansionRegion.h
@@ -63,7 +63,7 @@ public:
     BrowserExpansionRegion(const BrowserExpansionRegion * model, BrowserNode * p);
     virtual ~BrowserExpansionRegion();
 
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> & l,
+    virtual bool may_contains_them(const QList<BrowserNode *> & l,
                                    BooL & duplicable) const;
     virtual BrowserNode * duplicate(BrowserNode * p,
                                     QString name = QString());
@@ -101,7 +101,7 @@ public:
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;

--- a/src/browser/BrowserFlow.cpp
+++ b/src/browser/BrowserFlow.cpp
@@ -129,7 +129,7 @@ bool BrowserFlow::undelete(bool, QString & warning, QString & renamed)
     return TRUE;
 }
 
-void BrowserFlow::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserFlow::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -137,7 +137,7 @@ void BrowserFlow::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
         BrowserActivityDiagram::compute_referenced_by(l, this, "flowcanvas", "flow_ref");
 }
 
-void BrowserFlow::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserFlow::compute_referenced_by(QList<BrowserNode *> & l,
                                         const BrowserNode * target)
 {
     IdIterator<BrowserFlow> it(all);

--- a/src/browser/BrowserFlow.h
+++ b/src/browser/BrowserFlow.h
@@ -91,8 +91,8 @@ public:
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, const BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
+    static void compute_referenced_by(QList<BrowserNode *> &, const BrowserNode *);
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;

--- a/src/browser/BrowserInterruptibleActivityRegion.cpp
+++ b/src/browser/BrowserInterruptibleActivityRegion.cpp
@@ -122,7 +122,7 @@ void BrowserInterruptibleActivityRegion::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserInterruptibleActivityRegion::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserInterruptibleActivityRegion::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -561,17 +561,16 @@ bool BrowserInterruptibleActivityRegion::tool_cmd(ToolCom * com, const char * ar
     }
 }
 
-bool BrowserInterruptibleActivityRegion::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserInterruptibleActivityRegion::may_contains_them(const QList<BrowserNode *> & l,
         BooL & duplicable) const
 {
     BrowserNode * activity = get_container(UmlActivity);
-    Q3PtrListIterator<BrowserNode> it(l);
 
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlInterruptibleActivityRegion:
         case UmlExpansionRegion:
-            if (((const BrowserNode *) it.current()->get_container(UmlActivity)) != activity)
+            if (((const BrowserNode *) node->get_container(UmlActivity)) != activity)
                 return FALSE;
 
             break;
@@ -585,7 +584,7 @@ bool BrowserInterruptibleActivityRegion::may_contains_them(const Q3PtrList<Brows
         case MergeAN:
         case ForkAN:
         case JoinAN:
-            if (((const BrowserNode *) it.current()->get_container(UmlActivity)) != activity)
+            if (((const BrowserNode *) node->get_container(UmlActivity)) != activity)
                 return FALSE;
 
             break;
@@ -594,10 +593,10 @@ bool BrowserInterruptibleActivityRegion::may_contains_them(const Q3PtrList<Brows
             return FALSE;
         }
 
-        if (! may_contains(it.current(), TRUE))
+        if (! may_contains(node, TRUE))
             return FALSE;
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserInterruptibleActivityRegion.h
+++ b/src/browser/BrowserInterruptibleActivityRegion.h
@@ -62,7 +62,7 @@ public:
     BrowserInterruptibleActivityRegion(const BrowserInterruptibleActivityRegion * model, BrowserNode * p);
     virtual ~BrowserInterruptibleActivityRegion();
 
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> & l,
+    virtual bool may_contains_them(const QList<BrowserNode *> & l,
                                    BooL & duplicable) const;
     virtual BrowserNode * duplicate(BrowserNode * p,
                                     QString name = QString());
@@ -98,7 +98,7 @@ public:
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;

--- a/src/browser/BrowserNode.h
+++ b/src/browser/BrowserNode.h
@@ -91,7 +91,7 @@ protected:
 
     static bool show_stereotypes;
     static unsigned edition_number;
-    static Q3PtrList<BrowserNode> marked_list;
+    static QList<BrowserNode *> marked_list;
     static bool popup_menu_active;
     static QList<UmlCode> generatable_types;
     static SaveProgress * save_progress;
@@ -137,18 +137,12 @@ public:
     bool markedp() const {
         return is_marked;
     }
-    static const Q3PtrList<BrowserNode> & marked_nodes() {
+    static const QList<BrowserNode *> & marked_nodes() {
         return marked_list;
     }
     static const QList<BrowserNode*>  get_marked_nodes()
     {
-        Q3PtrListIterator<BrowserNode> it(marked_list);
-        QList<BrowserNode*> result;
-        for (; it.current() != 0; ++it)
-        {
-            result.append(it.current());
-        }
-        return result;
+        return marked_list;
     }
 
     static void setup_generatable_types();
@@ -184,7 +178,7 @@ public:
     const char * get_stereotype() const;
     virtual QString stereotypes_properties() const;
     bool may_contains(BrowserNode *, bool rec) const;
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> &,
+    virtual bool may_contains_them(const QList<BrowserNode *> &,
                                    BooL & duplicable) const;
     bool may_contains_it(BrowserNode * bn) const;
     virtual void move(BrowserNode *, BrowserNode * after);
@@ -256,7 +250,7 @@ public:
     virtual const QStringList & default_stereotypes(UmlCode, const BrowserNode *) const; // non class rel
     virtual BrowserNode * get_associated() const;
     virtual BasicData * add_relation(UmlCode, BrowserNode *);
-    virtual Q3PtrList<BrowserNode> parents() const;
+    virtual QList<BrowserNode *> parents() const;
     BrowserNode * get_container(UmlCode) const;
     virtual BrowserNode * container(UmlCode) const; // container for class, state machine and activity
     virtual QString check_inherit(const BrowserNode * parent) const;
@@ -266,7 +260,7 @@ public:
     virtual void member_cpp_def(const QString & prefix,
                                 const QString & prefix_tmplop,
                                 QString & s, bool templ) const;
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
     virtual AType class_association() const;
     virtual const char * constraint() const;
 
@@ -338,11 +332,8 @@ inline QString BrowserNode::fullname(QString & s, bool rev) const
 
 // a sortable list of BrowserNode
 
-class BrowserNodeList : public Q3PtrList<BrowserNode>
+class BrowserNodeList : public QList<BrowserNode *>
 {
-protected:
-    virtual int compareItems(Q3PtrCollection::Item item1, Q3PtrCollection::Item item2);
-
 public:
     void search(BrowserNode * bn, UmlCode k, const QString & s,
                 bool cs, bool even_deleted, bool for_name,
@@ -354,6 +345,10 @@ public:
     void full_names(QStringList & list) const;
     void full_defs(QStringList & list) const;
     void sort_it();
+    void sort();
+
+private:
+    static bool lessThan(BrowserNode *a, BrowserNode *b);
 };
 
 

--- a/src/browser/BrowserObjectDiagram.cpp
+++ b/src/browser/BrowserObjectDiagram.cpp
@@ -54,7 +54,7 @@
 #include "mu.h"
 #include "translate.h"
 
-Q3PtrList<BrowserObjectDiagram> BrowserObjectDiagram::imported;
+QList<BrowserObjectDiagram *> BrowserObjectDiagram::imported;
 Q3ValueList<int> BrowserObjectDiagram::imported_ids;
 QStringList BrowserObjectDiagram::its_default_stereotypes;	// unicode
 
@@ -156,15 +156,13 @@ void BrowserObjectDiagram::import()
 {
     Q3ValueList<int>::Iterator it = imported_ids.begin();
 
-    while (!imported.isEmpty()) {
-        QString warning;
-        BrowserObjectDiagram * d = imported.take(0);
-
+    foreach (BrowserObjectDiagram *d, imported) {
         (new ObjectDiagramWindow(d->full_name(), d, *it))->close(TRUE);
         d->set_diagram_window(nullptr);
         it = imported_ids.remove(it);
         d->is_modified = TRUE;
     }
+    imported.clear();
 }
 
 void BrowserObjectDiagram::renumber(int phase)
@@ -546,7 +544,7 @@ bool BrowserObjectDiagram::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-void BrowserObjectDiagram::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserObjectDiagram::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * bn,
         char const * kc,
         char const * kr)

--- a/src/browser/BrowserObjectDiagram.h
+++ b/src/browser/BrowserObjectDiagram.h
@@ -44,7 +44,7 @@ class BrowserObjectDiagram : public BrowserDiagram
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserObjectDiagram> imported;
+    static QList<BrowserObjectDiagram *> imported;
     static Q3ValueList<int> imported_ids;
     static QStringList its_default_stereotypes;
 
@@ -116,7 +116,7 @@ public:
     static void open_all();
     static void import();
 
-    static void compute_referenced_by(Q3PtrList<BrowserNode> & l, BrowserNode *,
+    static void compute_referenced_by(QList<BrowserNode *> & l, BrowserNode *,
                                       const char * kc, char const * kr);
 };
 

--- a/src/browser/BrowserOperation.cpp
+++ b/src/browser/BrowserOperation.cpp
@@ -219,7 +219,7 @@ bool BrowserOperation::delete_internal(QString &)
     is_deleted = TRUE;
 
     if (is_marked) {
-        marked_list.removeRef(this);
+        marked_list.remove(this);
         is_marked = FALSE;
     }
 
@@ -233,7 +233,7 @@ void BrowserOperation::AddConstructorInitalizer()
 {
     ConstructorInitializerDialog ciDialog;
     BrowserClass* container = static_cast<BrowserClass*>(get_container(UmlClass));
-    Q3PtrList<BrowserNode> parents = container->parents();
+    QList<BrowserNode *> parents = container->parents();
     QString initializerDummy(" : ");
     for(BrowserNode* parent : parents)
     {
@@ -586,7 +586,7 @@ void BrowserOperation::paintCell(QPainter * p, const QColorGroup & cg, int colum
     }
 }
 
-static Q3PtrList<BrowserNode> ImplBy;
+static QList<BrowserNode *> ImplBy;
 static const int add_constructor_initializer = 35;
 static const int go_up = 36;
 
@@ -664,10 +664,9 @@ void BrowserOperation::menu()
                 MenuFactory::createTitle(implbym, TR("Choose behavior"));
                 implbym.insertSeparator();
 
-                BrowserNode * beh;
                 int rank = 10000;
 
-                for (beh = ImplBy.first(); beh != 0; beh = ImplBy.next())
+                foreach (BrowserNode * beh, ImplBy)
                     implbym.insertItem(beh->full_name(TRUE), rank);
             }
 
@@ -950,7 +949,7 @@ void BrowserOperation::member_cpp_def(const QString & prefix,
     }
 }
 
-void BrowserOperation::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserOperation::compute_referenced_by(QList<BrowserNode *> & l,
                                              BrowserClass * target)
 {
     IdIterator<BrowserOperation> it(all);
@@ -963,7 +962,7 @@ void BrowserOperation::compute_referenced_by(Q3PtrList<BrowserNode> & l,
     }
 }
 
-void BrowserOperation::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserOperation::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -1003,16 +1002,14 @@ bool BrowserOperation::tool_cmd(ToolCom * com, const char * args)
         return TRUE;
 
     case sideCmd: {
-        Q3PtrList<BrowserNode> l;
+        QList<BrowserNode *> l;
 
         BrowserActivity::compute_referenced_by(l, this);
         BrowserState::compute_referenced_by(l, this);
 
         com->write_unsigned(l.count());
 
-        BrowserNode * bn;
-
-        for (bn = l.first(); bn != 0; bn = l.next())
+        foreach (BrowserNode * bn, l)
             bn->write_id(com);
     }
 

--- a/src/browser/BrowserOperation.h
+++ b/src/browser/BrowserOperation.h
@@ -127,8 +127,8 @@ public:
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserClass *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserClass *);
 
     static QString python_init_self(BrowserNode * cl);
 

--- a/src/browser/BrowserPackage.cpp
+++ b/src/browser/BrowserPackage.cpp
@@ -101,7 +101,7 @@
 #include "translate.h"
 
 IdDict<BrowserPackage> BrowserPackage::all(__FILE__);
-Q3PtrList<BrowserPackage> BrowserPackage::removed;
+QList<BrowserPackage *> BrowserPackage::removed;
 
 QStringList BrowserPackage::its_default_stereotypes;	// unicode
 QStringList BrowserPackage::relation_default_stereotypes;	// unicode
@@ -419,7 +419,7 @@ void BrowserPackage::support_file(Q3Dict<char> & files, bool add) const
         ((BrowserNode *) child)->support_file(files, add);
 }
 
-void BrowserPackage::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserPackage::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -2035,13 +2035,11 @@ void BrowserPackage::DragMoveInsideEvent(QDragMoveEvent * e)
         e->ignore();
 }
 
-bool BrowserPackage::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserPackage::may_contains_them(const QList<BrowserNode *> & l,
                                        BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlPackage:
         case UmlUseCaseView:
         case UmlClassView:
@@ -2050,14 +2048,14 @@ bool BrowserPackage::may_contains_them(const Q3PtrList<BrowserNode> & l,
             break;
 
         default:
-            if (!IsaSimpleRelation(it.current()->get_type()) ||
-                    (((const BrowserNode *) it.current()->parent()) != this))
+            if (!IsaSimpleRelation(node->get_type()) ||
+                    (((const BrowserNode *) node->parent()) != this))
                 return FALSE;
         }
 
         duplicable = FALSE;
 
-        if (! may_contains(it.current(), FALSE))
+        if (! may_contains(node, FALSE))
             return FALSE;
     }
 
@@ -2592,13 +2590,11 @@ void BrowserPackage::save_session(QTextStream & st)
     QString warning;
 
     if (! marked_list.isEmpty()) {
-        Q3PtrListIterator<BrowserNode> it(marked_list);
-
         st << "marked\n";
 
-        for (; it.current() != 0; ++it) {
+        foreach (BrowserNode *node, marked_list) {
             st << "  ";
-            it.current()->save(st, TRUE, warning);
+            node->save(st, TRUE, warning);
             st << '\n';
         }
 

--- a/src/browser/BrowserPackage.h
+++ b/src/browser/BrowserPackage.h
@@ -48,7 +48,7 @@ class BrowserPackage : public BrowserNode, public Labeled<BrowserPackage>
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserPackage> removed;
+    static QList<BrowserPackage *> removed;
     static IdDict<BrowserPackage> all;
 
     static QStringList its_default_stereotypes;
@@ -115,7 +115,7 @@ public:
     virtual QString get_stype() const;
     virtual int get_identifier() const;
     virtual const char * help_topic() const;
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> &,
+    virtual bool may_contains_them(const QList<BrowserNode *> &,
                                    BooL & duplicable) const;
     virtual BasicData * get_data() const;
     virtual const QStringList & default_stereotypes(UmlCode, const BrowserNode *) const; // non class rel
@@ -134,7 +134,7 @@ public:
     virtual QString check_inherit(const BrowserNode * parent) const;
     QString may_connect(UmlCode & l, const BrowserNode * dest) const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
     static bool tool_global_cmd(ToolCom * com, const char * args);

--- a/src/browser/BrowserParameter.cpp
+++ b/src/browser/BrowserParameter.cpp
@@ -336,7 +336,7 @@ QString BrowserParameter::full_name(bool rev, bool) const
     return fullname(rev);
 }
 
-void BrowserParameter::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserParameter::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserFlow::compute_referenced_by(l, this);
@@ -345,7 +345,7 @@ void BrowserParameter::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
         BrowserActivityDiagram::compute_referenced_by(l, this, "parametercanvas", "parameter_ref");
 }
 
-void BrowserParameter::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserParameter::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * target)
 {
     IdIterator<BrowserParameter> it(all);

--- a/src/browser/BrowserParameter.h
+++ b/src/browser/BrowserParameter.h
@@ -90,8 +90,8 @@ public:
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserNode *);
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;

--- a/src/browser/BrowserParameterSet.cpp
+++ b/src/browser/BrowserParameterSet.cpp
@@ -118,7 +118,7 @@ void BrowserParameterSet::prepare_update_lib() const
     all.memo_id_oid(get_ident(), original_id);
 }
 
-void BrowserParameterSet::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserParameterSet::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 

--- a/src/browser/BrowserParameterSet.h
+++ b/src/browser/BrowserParameterSet.h
@@ -81,7 +81,7 @@ public:
 
     static BrowserParameterSet * new_one(const char *, BrowserNode * p);
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
 
     static void clear(bool old);
     static void update_idmax_for_root();

--- a/src/browser/BrowserPin.cpp
+++ b/src/browser/BrowserPin.cpp
@@ -139,7 +139,7 @@ const QPixmap * BrowserPin::pixmap(int) const
         return PinIcon;
 }
 
-void BrowserPin::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserPin::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -147,7 +147,7 @@ void BrowserPin::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
         BrowserActivityDiagram::compute_referenced_by(l, this, "pincanvas", "pin_ref");
 }
 
-void BrowserPin::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserPin::compute_referenced_by(QList<BrowserNode *> & l,
                                        BrowserNode * target)
 {
     IdIterator<BrowserPin> it(all);

--- a/src/browser/BrowserPin.h
+++ b/src/browser/BrowserPin.h
@@ -97,8 +97,8 @@ public:
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserNode *);
 
     virtual void DropAfterEvent(QDropEvent * e, BrowserNode * after);
     QString drag_key() const;

--- a/src/browser/BrowserPseudoState.cpp
+++ b/src/browser/BrowserPseudoState.cpp
@@ -122,7 +122,7 @@ void BrowserPseudoState::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserPseudoState::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserPseudoState::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserTransition::compute_referenced_by(l, this);

--- a/src/browser/BrowserPseudoState.h
+++ b/src/browser/BrowserPseudoState.h
@@ -96,8 +96,8 @@ public:
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserPseudoState *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserPseudoState *);
 
     bool allow_empty() const;
     static bool allow_empty(UmlCode c);

--- a/src/browser/BrowserRegion.cpp
+++ b/src/browser/BrowserRegion.cpp
@@ -414,13 +414,11 @@ bool BrowserRegion::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-bool BrowserRegion::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserRegion::may_contains_them(const QList<BrowserNode *> & l,
                                       BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlState:
             break;
 
@@ -435,16 +433,16 @@ bool BrowserRegion::may_contains_them(const Q3PtrList<BrowserNode> & l,
         case ChoicePS:
         case ForkPS:
         case JoinPS:
-            return (((const BrowserNode *) it.current()->parent()) == this);
+            return (((const BrowserNode *) node->parent()) == this);
 
         default:
             return FALSE;
         }
 
-        if (! may_contains(it.current(), FALSE))
+        if (! may_contains(node, FALSE))
             return FALSE;
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserRegion.h
+++ b/src/browser/BrowserRegion.h
@@ -61,7 +61,7 @@ public:
     BrowserRegion(const BrowserRegion * model, BrowserNode * p);
     virtual ~BrowserRegion();
 
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> & l,
+    virtual bool may_contains_them(const QList<BrowserNode *> & l,
                                    BooL & duplicable) const;
     static BrowserRegion * add_region(BrowserNode * future_parent,
                                       const char * s = "region");

--- a/src/browser/BrowserRelation.cpp
+++ b/src/browser/BrowserRelation.cpp
@@ -61,7 +61,7 @@
 #include "translate.h"
 
 IdDict<BrowserRelation> BrowserRelation::all(1021, __FILE__);
-static Q3PtrList<BrowserRelation> Unconsistent;
+static QList<BrowserRelation *> Unconsistent;
 
 BrowserRelation::BrowserRelation(BrowserNode * p, RelationData * d, int id)
     : BrowserNode(d->get_name(), p), Labeled<BrowserRelation>(all, id),
@@ -214,7 +214,7 @@ UmlVisibility BrowserRelation::get_visibility() const
     return def->get_uml_visibility_a();
 }
 
-void BrowserRelation::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserRelation::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserClass * target)
 {
     IdIterator<BrowserRelation> it(all);
@@ -232,7 +232,7 @@ void BrowserRelation::compute_referenced_by(Q3PtrList<BrowserNode> & l,
     }
 }
 
-void BrowserRelation::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserRelation::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserClassInstance::compute_referenced_by(l, this);
@@ -1000,12 +1000,12 @@ void BrowserRelation::post_load()
         ++it;
     }
 
-    while (!Unconsistent.isEmpty()) {
-        br = Unconsistent.take(0);
+    foreach (BrowserRelation *br, Unconsistent) {
         br->def->set_unconsistent();
         br->def = 0;
         br->must_be_deleted();
     }
+    Unconsistent.clear();
 
     if (RelationData::has_unconsistencies()) {
         IdIterator<BrowserRelation> it2(all);

--- a/src/browser/BrowserRelation.h
+++ b/src/browser/BrowserRelation.h
@@ -125,8 +125,8 @@ public:
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserClass *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserClass *);
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
 

--- a/src/browser/BrowserSeqDiagram.cpp
+++ b/src/browser/BrowserSeqDiagram.cpp
@@ -53,7 +53,7 @@
 #include "mu.h"
 #include "translate.h"
 
-Q3PtrList<BrowserSeqDiagram> BrowserSeqDiagram::imported;
+QList<BrowserSeqDiagram *> BrowserSeqDiagram::imported;
 Q3ValueList<int> BrowserSeqDiagram::imported_ids;
 QStringList BrowserSeqDiagram::its_default_stereotypes;	// unicode
 QStringList BrowserSeqDiagram::message_default_stereotypes;	// unicode
@@ -160,14 +160,12 @@ void BrowserSeqDiagram::import()
 {
     Q3ValueList<int>::Iterator it = imported_ids.begin();
 
-    while (!imported.isEmpty()) {
-        QString warning;
-        BrowserSeqDiagram * d = imported.take(0);
-
+    foreach (BrowserSeqDiagram *d, imported) {
         (new SeqDiagramWindow(d->full_name(), d, *it))->close(TRUE);
         it = imported_ids.remove(it);
         d->is_modified = TRUE;
     }
+    imported.clear();
 }
 
 void BrowserSeqDiagram::renumber(int phase)
@@ -575,7 +573,7 @@ bool BrowserSeqDiagram::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-void BrowserSeqDiagram::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserSeqDiagram::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * bn,
         char const * kc,
         char const * kr)

--- a/src/browser/BrowserSeqDiagram.h
+++ b/src/browser/BrowserSeqDiagram.h
@@ -44,7 +44,7 @@ class BrowserSeqDiagram : public BrowserDiagram
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserSeqDiagram> imported;
+    static QList<BrowserSeqDiagram *> imported;
     static Q3ValueList<int> imported_ids;
     static QStringList its_default_stereotypes;
     static QStringList message_default_stereotypes;
@@ -122,7 +122,7 @@ public:
     static void open_all();
     static void import();
 
-    static void compute_referenced_by(Q3PtrList<BrowserNode> & l, BrowserNode *,
+    static void compute_referenced_by(QList<BrowserNode *> & l, BrowserNode *,
                                       const char * kc, char const * kr);
 };
 

--- a/src/browser/BrowserSimpleRelation.cpp
+++ b/src/browser/BrowserSimpleRelation.cpp
@@ -151,7 +151,7 @@ bool BrowserSimpleRelation::undelete(bool, QString & warning, QString & renamed)
     return TRUE;
 }
 
-void BrowserSimpleRelation::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserSimpleRelation::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -168,7 +168,7 @@ void BrowserSimpleRelation::referenced_by(Q3PtrList<BrowserNode> & l, bool ondel
     }
 }
 
-void BrowserSimpleRelation::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserSimpleRelation::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * target)
 {
     IdIterator<BrowserSimpleRelation> it(all);

--- a/src/browser/BrowserSimpleRelation.h
+++ b/src/browser/BrowserSimpleRelation.h
@@ -86,8 +86,8 @@ public:
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserNode *);
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
 

--- a/src/browser/BrowserState.cpp
+++ b/src/browser/BrowserState.cpp
@@ -129,7 +129,7 @@ void BrowserState::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserState::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserState::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserTransition::compute_referenced_by(l, this);
@@ -151,7 +151,7 @@ void BrowserState::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
 }
 
 // callers suppose this only take specification into acount
-void BrowserState::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserState::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserOperation * op)
 {
     IdIterator<BrowserState> it(all);
@@ -754,14 +754,13 @@ BrowserState * BrowserState::get_machine(const BrowserNode * bn)
     }
 }
 
-bool BrowserState::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserState::may_contains_them(const QList<BrowserNode *> & l,
                                      BooL & duplicable) const
 {
     BrowserNode * machine = get_machine(this);
-    Q3PtrListIterator<BrowserNode> it(l);
 
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlTransition:
 
             // no break !
@@ -787,7 +786,7 @@ bool BrowserState::may_contains_them(const Q3PtrList<BrowserNode> & l,
             // no break
         case EntryPointPS:
         case ExitPointPS:
-            if (get_machine(it.current()) != machine)
+            if (get_machine(node) != machine)
                 return FALSE;
 
             break;
@@ -796,10 +795,10 @@ bool BrowserState::may_contains_them(const Q3PtrList<BrowserNode> & l,
             return FALSE;
         }
 
-        if (! BrowserNode::may_contains(it.current(), TRUE))
+        if (! BrowserNode::may_contains(node, TRUE))
             return FALSE;
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserState.h
+++ b/src/browser/BrowserState.h
@@ -65,7 +65,7 @@ public:
     virtual ~BrowserState();
 
     bool may_contains(UmlCode k) const;
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> & l,
+    virtual bool may_contains_them(const QList<BrowserNode *> & l,
                                    BooL & duplicable) const;
     virtual BrowserNode * duplicate(BrowserNode * p,
                                     QString name = QString());
@@ -107,8 +107,8 @@ public:
     virtual bool tool_cmd(ToolCom * com, const char * args);
     virtual bool api_compatible(unsigned v) const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserOperation *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserOperation *);
 
     bool is_ref() const;
     bool can_reference() const;

--- a/src/browser/BrowserStateAction.cpp
+++ b/src/browser/BrowserStateAction.cpp
@@ -119,7 +119,7 @@ void BrowserStateAction::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserStateAction::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserStateAction::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
     BrowserTransition::compute_referenced_by(l, this);

--- a/src/browser/BrowserStateAction.h
+++ b/src/browser/BrowserStateAction.h
@@ -92,8 +92,8 @@ public:
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> &, bool ondelete = FALSE);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserStateAction *);
+    virtual void referenced_by(QList<BrowserNode *> &, bool ondelete = FALSE);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserStateAction *);
 
     bool allow_empty() const;
 

--- a/src/browser/BrowserStateDiagram.cpp
+++ b/src/browser/BrowserStateDiagram.cpp
@@ -55,7 +55,7 @@
 #include "mu.h"
 #include "translate.h"
 
-Q3PtrList<BrowserStateDiagram> BrowserStateDiagram::imported;
+QList<BrowserStateDiagram *> BrowserStateDiagram::imported;
 Q3ValueList<int> BrowserStateDiagram::imported_ids;
 QStringList BrowserStateDiagram::its_default_stereotypes;	// unicode
 
@@ -151,14 +151,12 @@ void BrowserStateDiagram::import()
 {
     Q3ValueList<int>::Iterator it = imported_ids.begin();
 
-    while (!imported.isEmpty()) {
-        QString warning;
-        BrowserStateDiagram * d = imported.take(0);
-
+    foreach (BrowserStateDiagram *d, imported) {
         (new StateDiagramWindow(d->full_name(), d, *it))->close(TRUE);
         it = imported_ids.remove(it);
         d->is_modified = TRUE;
     }
+    imported.clear();
 }
 
 void BrowserStateDiagram::renumber(int phase)
@@ -592,7 +590,7 @@ const QStringList & BrowserStateDiagram::default_stereotypes()
     return its_default_stereotypes;
 }
 
-void BrowserStateDiagram::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserStateDiagram::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * bn,
         char const * kc,
         char const * kr)

--- a/src/browser/BrowserStateDiagram.h
+++ b/src/browser/BrowserStateDiagram.h
@@ -45,7 +45,7 @@ class BrowserStateDiagram : public BrowserDiagram
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserStateDiagram> imported;
+    static QList<BrowserStateDiagram *> imported;
     static Q3ValueList<int> imported_ids;
     static QStringList its_default_stereotypes;
 
@@ -117,7 +117,7 @@ public:
     static void open_all();
     static void import();
 
-    static void compute_referenced_by(Q3PtrList<BrowserNode> & l, BrowserNode *,
+    static void compute_referenced_by(QList<BrowserNode *> & l, BrowserNode *,
                                       const char * kc, char const * kr);
 
     static QString drag_key(BrowserNode * p);

--- a/src/browser/BrowserTransition.cpp
+++ b/src/browser/BrowserTransition.cpp
@@ -128,7 +128,7 @@ bool BrowserTransition::undelete(bool, QString & warning, QString & renamed)
     return TRUE;
 }
 
-void BrowserTransition::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserTransition::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -136,7 +136,7 @@ void BrowserTransition::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
         BrowserStateDiagram::compute_referenced_by(l, this, "transitioncanvas", "transition_ref");
 }
 
-void BrowserTransition::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserTransition::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * target)
 {
     IdIterator<BrowserTransition> it(all);

--- a/src/browser/BrowserTransition.h
+++ b/src/browser/BrowserTransition.h
@@ -88,8 +88,8 @@ public:
     virtual void renumber(int phase);
     virtual void prepare_update_lib() const;
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
-    static void compute_referenced_by(Q3PtrList<BrowserNode> &, BrowserNode *);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
+    static void compute_referenced_by(QList<BrowserNode *> &, BrowserNode *);
 
     virtual bool tool_cmd(ToolCom * com, const char * args);
 

--- a/src/browser/BrowserUseCase.cpp
+++ b/src/browser/BrowserUseCase.cpp
@@ -174,7 +174,7 @@ void BrowserUseCase::prepare_update_lib() const
         ((BrowserNode *) child)->prepare_update_lib();
 }
 
-void BrowserUseCase::referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete)
+void BrowserUseCase::referenced_by(QList<BrowserNode *> & l, bool ondelete)
 {
     BrowserNode::referenced_by(l, ondelete);
 
@@ -961,13 +961,11 @@ void BrowserUseCase::DragMoveInsideEvent(QDragMoveEvent * e)
         e->ignore();
 }
 
-bool BrowserUseCase::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserUseCase::may_contains_them(const QList<BrowserNode *> & l,
                                        BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlUseCaseDiagram:
         case UmlSeqDiagram:
         case UmlColDiagram:
@@ -981,17 +979,17 @@ bool BrowserUseCase::may_contains_them(const Q3PtrList<BrowserNode> & l,
             break;
 
         default:
-            if (!IsaSimpleRelation(it.current()->get_type()) ||
-                (((const BrowserNode *) it.current()->parent()) != this))
+            if (!IsaSimpleRelation(node->get_type()) ||
+                (((const BrowserNode *) node->parent()) != this))
                 return FALSE;
 
             duplicable = FALSE;
         }
 
-        if (! may_contains(it.current(), FALSE))
+        if (! may_contains(node, FALSE))
             return FALSE;
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserUseCase.h
+++ b/src/browser/BrowserUseCase.h
@@ -101,7 +101,7 @@ public:
     virtual int get_identifier() const;
     virtual const char * help_topic() const;
     virtual void modified();
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> &,
+    virtual bool may_contains_them(const QList<BrowserNode *> &,
                                    BooL & duplicable) const;
     virtual BasicData * get_data() const;
     virtual void get_usecasediagramsettings(UseCaseDiagramSettings &) const;
@@ -129,7 +129,7 @@ public:
     static void read_stereotypes(char *& , char *& k);
     static void save_stereotypes(QTextStream &);
 
-    virtual void referenced_by(Q3PtrList<BrowserNode> & l, bool ondelete);
+    virtual void referenced_by(QList<BrowserNode *> & l, bool ondelete);
 
     static void clear(bool old);
     static void update_idmax_for_root();

--- a/src/browser/BrowserUseCaseDiagram.cpp
+++ b/src/browser/BrowserUseCaseDiagram.cpp
@@ -55,7 +55,7 @@
 #include "mu.h"
 #include "translate.h"
 
-Q3PtrList<BrowserUseCaseDiagram> BrowserUseCaseDiagram::imported;
+QList<BrowserUseCaseDiagram *> BrowserUseCaseDiagram::imported;
 Q3ValueList<int> BrowserUseCaseDiagram::imported_ids;
 QStringList BrowserUseCaseDiagram::its_default_stereotypes;	// unicode
 
@@ -160,14 +160,12 @@ void BrowserUseCaseDiagram::import()
 {
     Q3ValueList<int>::Iterator it = imported_ids.begin();
 
-    while (!imported.isEmpty()) {
-        QString warning;
-        BrowserUseCaseDiagram * d = imported.take(0);
-
+    foreach (BrowserUseCaseDiagram *d, imported) {
         (new UseCaseDiagramWindow(d->full_name(), d, *it))->close(TRUE);
         it = imported_ids.remove(it);
         d->is_modified = TRUE;
     }
+    imported.clear();
 }
 
 void BrowserUseCaseDiagram::renumber(int phase)
@@ -570,7 +568,7 @@ bool BrowserUseCaseDiagram::tool_cmd(ToolCom * com, const char * args)
     }
 }
 
-void BrowserUseCaseDiagram::compute_referenced_by(Q3PtrList<BrowserNode> & l,
+void BrowserUseCaseDiagram::compute_referenced_by(QList<BrowserNode *> & l,
         BrowserNode * bn,
         char const * kc,
         char const * kr)

--- a/src/browser/BrowserUseCaseDiagram.h
+++ b/src/browser/BrowserUseCaseDiagram.h
@@ -44,7 +44,7 @@ class BrowserUseCaseDiagram : public BrowserDiagram
     friend class StereotypesDialog;
 
 protected:
-    static Q3PtrList<BrowserUseCaseDiagram> imported;
+    static QList<BrowserUseCaseDiagram *> imported;
     static Q3ValueList<int> imported_ids;
     static QStringList its_default_stereotypes;
 
@@ -114,7 +114,7 @@ public:
     static void open_all();
     static void import();
 
-    static void compute_referenced_by(Q3PtrList<BrowserNode> & l, BrowserNode *,
+    static void compute_referenced_by(QList<BrowserNode *> & l, BrowserNode *,
                                       const char * kc, char const * kr);
 };
 

--- a/src/browser/BrowserUseCaseView.cpp
+++ b/src/browser/BrowserUseCaseView.cpp
@@ -830,13 +830,11 @@ void BrowserUseCaseView::DragMoveInsideEvent(QDragMoveEvent * e)
         e->ignore();
 }
 
-bool BrowserUseCaseView::may_contains_them(const Q3PtrList<BrowserNode> & l,
+bool BrowserUseCaseView::may_contains_them(const QList<BrowserNode *> & l,
         BooL & duplicable) const
 {
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    for (; it.current(); ++it) {
-        switch (it.current()->get_type()) {
+    foreach (BrowserNode *node, l) {
+        switch (node->get_type()) {
         case UmlUseCaseView:
             duplicable = FALSE;
 
@@ -851,7 +849,7 @@ bool BrowserUseCaseView::may_contains_them(const Q3PtrList<BrowserNode> & l,
         case UmlObjectDiagram:
         case UmlState:
         case UmlActivity:
-            if (! may_contains(it.current(), FALSE))
+            if (! may_contains(node, FALSE))
                 return FALSE;
 
             break;
@@ -860,7 +858,7 @@ bool BrowserUseCaseView::may_contains_them(const Q3PtrList<BrowserNode> & l,
             return FALSE;
         }
 
-        duplicable = may_contains_it(it.current());
+        duplicable = may_contains_it(node);
     }
 
     return TRUE;

--- a/src/browser/BrowserUseCaseView.h
+++ b/src/browser/BrowserUseCaseView.h
@@ -95,7 +95,7 @@ public:
     virtual QString get_stype() const;
     virtual int get_identifier() const;
     virtual const char * help_topic() const;
-    virtual bool may_contains_them(const Q3PtrList<BrowserNode> &,
+    virtual bool may_contains_them(const QList<BrowserNode *> &,
                                    BooL & duplicable) const;
     virtual BrowserNode * container(UmlCode) const; // container for class, state machine and activity
     virtual BasicData * get_data() const;

--- a/src/data/BasicData.cpp
+++ b/src/data/BasicData.cpp
@@ -54,7 +54,7 @@ void BasicParent::removeChild(QObject *)
 
 //
 
-Q3PtrList<BasicData> BasicData::removed;
+QList<BasicData *> BasicData::removed;
 
 BasicData::BasicData(const BasicData * model)
     : QObject(&BasicParent::the), browser_node(0)
@@ -81,16 +81,14 @@ void BasicData::undelete(QString &, QString &)
     if (deletedp()) {
         set_deletedp(FALSE);
         emit changed();
-        removed.removeRef(this);
+        removed.remove(this);
     }
 }
 
 void BasicData::resignal_deleted()
 {
-    BasicData * d;
-
-    for (d = removed.last(); d != 0; d = removed.prev())
-        d->redelete_it();
+    for (int i = removed.size() - 1; i >= 0; --i)
+        removed[i]->redelete_it();
 }
 
 void BasicData::on_delete()

--- a/src/data/BasicData.h
+++ b/src/data/BasicData.h
@@ -67,7 +67,7 @@ class BasicData : public QObject
     Q_OBJECT
 
 protected:
-    static Q3PtrList<BasicData> removed;
+    static QList<BasicData *> removed;
 
     WrapperStr stereotype;
     BrowserNode * browser_node;

--- a/src/data/ClassData.h
+++ b/src/data/ClassData.h
@@ -54,7 +54,7 @@ class ClassData : public BasicData
 protected:
     WrapperStr constraint;
     FormalParamData * formals;		// remark : do NOT use QArray
-    Q3PtrList<ActualParamData> actuals;
+    QList<ActualParamData *> actuals;
     AType base_type;			// typedef
     unsigned char nformals;
     bool is_deleted : 1;
@@ -105,9 +105,9 @@ protected:
     virtual void send_idl_def(ToolCom * com);
 
     void update_actuals(BrowserClass *,
-                        Q3PtrList<ActualParamData> & new_actuals,
-                        Q3PtrList<ActualParamData> & managed);
-    void get_actuals(Q3PtrList<ActualParamData> & l, BrowserClass * parent);
+                        QList<ActualParamData *> & new_actuals,
+                        QList<ActualParamData *> & managed);
+    void get_actuals(QList<ActualParamData *> & l, BrowserClass * parent);
 
 public:
     ClassData();

--- a/src/data/ClassInstanceData.cpp
+++ b/src/data/ClassInstanceData.cpp
@@ -141,7 +141,7 @@ void ClassInstanceData::init_other_side()
 
                 BasicData * d = slot_rel.rel->get_end_class()->get_data();
 
-                if (other_data->connect_list.findRef(d) == -1) {
+                if (! other_data->connect_list.contains(d)) {
                     other_data->connect_list.append(d);
                     connect(d, SIGNAL(changed()), other_data, SLOT(check()));
                     connect(d, SIGNAL(deleted()), other_data, SLOT(check()));
@@ -163,7 +163,7 @@ void ClassInstanceData::check()
         browser_node->delete_it();
     else if (!attributes.isEmpty() || !relations.isEmpty()) {
         bool modif = FALSE;
-        Q3PtrList<BrowserClass> l;
+        QList<BrowserClass *> l;
 
         cl->get_all_parents(l);
         l.append(cl);
@@ -176,7 +176,7 @@ void ClassInstanceData::check()
             const SlotAttr & slot_attr = *it_attr;
 
             if (slot_attr.att->deletedp() ||
-                (l.findRef((BrowserClass *) slot_attr.att->parent())  == -1)) {
+                (! l.contains((BrowserClass *) slot_attr.att->parent()))) {
                 // must be removed
                 it_attr = attributes.remove(it_attr);
                 modif = TRUE;
@@ -185,7 +185,7 @@ void ClassInstanceData::check()
                 // change on attribute modify class => memorize classes only
                 BasicData * cld = ((BrowserNode *) slot_attr.att->parent())->get_data();
 
-                if (connect_list.findRef(cld) == -1) {
+                if (! connect_list.contains(cld)) {
                     connect_list.append(cld);
                     connect(cld, SIGNAL(changed()), this, SLOT(check()));
                     connect(cld, SIGNAL(deleted()), this, SLOT(check()));
@@ -215,7 +215,7 @@ void ClassInstanceData::check()
                 it_rel = relations.remove(it_rel);
                 modif = TRUE;
             }
-            else if (l.findRef((BrowserClass *) br->parent()) == -1) {
+            else if (!l.contains((BrowserClass *) br->parent())) {
                 // new instance type, must be removed in both side
                 if (slot_rel.value->get_data() != this) {
                     // not reflexive
@@ -245,7 +245,7 @@ void ClassInstanceData::check()
 
                 d = ((BrowserNode *) br->parent())->get_data();
 
-                if (connect_list.findRef(d) == -1) {
+                if (! connect_list.contains(d)) {
                     connect_list.append(d);
                     connect(d, SIGNAL(changed()), this, SLOT(check()));
                     connect(d, SIGNAL(deleted()), this, SLOT(check()));
@@ -253,7 +253,7 @@ void ClassInstanceData::check()
 
                 d = slot_rel.value->get_data();
 
-                if (connect_list.findRef(d) == -1) {
+                if (! connect_list.contains(d)) {
                     connect_list.append(d);
                     connect(d, SIGNAL(changed()), this, SLOT(check_rels()));
                     connect(d, SIGNAL(deleted()), this, SLOT(check_rels()));
@@ -293,10 +293,10 @@ void ClassInstanceData::check_rels()
                 remove = TRUE;
             }
             else if (cl != other) {
-                Q3PtrList<BrowserClass> l;
+                QList<BrowserClass *> l;
 
                 cl->get_all_parents(l);
-                remove |= (l.findRef(other) == -1);
+                remove |= (! l.contains(other));
             }
         }
 
@@ -361,7 +361,7 @@ void ClassInstanceData::add(BrowserClassInstance * other,
 
     BasicData * d = rd->get_start_class()->get_data();
 
-    if (connect_list.findRef(d) == -1) {
+    if (! connect_list.contains(d)) {
         connect_list.append(d);
         connect(d, SIGNAL(changed()), this, SLOT(check()));
         connect(d, SIGNAL(deleted()), this, SLOT(check()));
@@ -374,7 +374,7 @@ void ClassInstanceData::add(BrowserClassInstance * other,
 
         d = rd->get_end_class()->get_data();
 
-        if (od->connect_list.findRef(d) == -1) {
+        if (! od->connect_list.contains(d)) {
             od->connect_list.append(d);
             connect(d, SIGNAL(changed()), od, SLOT(check()));
             connect(d, SIGNAL(deleted()), od, SLOT(check()));
@@ -410,7 +410,7 @@ void ClassInstanceData::replace_internal(BrowserClassInstance * other,
                     ((BrowserNode *) future->get_start()->parent())
                     ->get_data();
 
-                if (connect_list.findRef(d) == -1) {
+                if (! connect_list.contains(d)) {
                     connect_list.append(d);
                     connect(d, SIGNAL(changed()), this, SLOT(check()));
                     connect(d, SIGNAL(deleted()), this, SLOT(check()));
@@ -428,7 +428,7 @@ void ClassInstanceData::replace_internal(BrowserClassInstance * other,
 
         BasicData * d = future->get_start_class()->get_data();
 
-        if (connect_list.findRef(d) == -1) {
+        if (! connect_list.contains(d)) {
             connect_list.append(d);
             connect(d, SIGNAL(changed()), this, SLOT(check()));
             connect(d, SIGNAL(deleted()), this, SLOT(check()));
@@ -491,8 +491,9 @@ void ClassInstanceData::set_class(BrowserClass * t)
             replace(slot_rel.value, slot_rel.rel, 0, slot_rel.is_a, FALSE);
         }
 
-        while (!connect_list.isEmpty())
-            disconnect(connect_list.take(0), 0, this, 0);
+        foreach (BasicData *data, connect_list)
+            disconnect(data, 0, this, 0);
+        connect_list.clear();
 
         BasicData * cld = cl->get_data();
 
@@ -553,13 +554,13 @@ bool ClassInstanceData::tool_cmd(ToolCom * com, const char * args,
 
                 if (! find) {
                     // add it
-                    Q3PtrList<BrowserClass> l;
+                    QList<BrowserClass *> l;
 
                     cl->get_all_parents(l);
                     l.append(cl);
 
                     if (at->deletedp() ||
-                        (l.findRef((BrowserClass *) at->parent())  == -1)) {
+                        (! l.contains((BrowserClass *)at->parent()))) {
                         // illegal
                         com->write_ack(FALSE);
                         return TRUE;
@@ -610,13 +611,12 @@ bool ClassInstanceData::tool_cmd(ToolCom * com, const char * args,
             else {
                 // get all available attributes
                 BrowserNodeList l;
-                BrowserNode * bn;
 
                 cl->get_attrs(l);
                 com->write_unsigned(l.count());
 
-                for (bn = l.first(); bn != 0; bn = l.next())
-                    bn->write_id(com);
+                foreach (BrowserNode * node, l)
+                    node->write_id(com);
             }
 
             break;
@@ -640,13 +640,12 @@ bool ClassInstanceData::tool_cmd(ToolCom * com, const char * args,
             }
             else {
                 // get all available relations
-                Q3PtrList<BrowserRelation> l;
-                BrowserRelation * r;
+                QList<BrowserRelation *> l;
 
                 cl->get_rels(((ClassInstanceData *)other->get_data())->cl, l);
                 com->write_unsigned(l.count());
 
-                for (r = l.first(); r != 0; r = l.next())
+                foreach (BrowserRelation *r, l)
                     r->write_id(com);
             }
         }
@@ -687,11 +686,11 @@ bool ClassInstanceData::change_rel(ToolCom * com, const char * args,
     if (isadd) {
         if (it == relations.end()) {
             // not yet present
-            Q3PtrList<BrowserRelation> l;
+            QList<BrowserRelation *> l;
 
             cl->get_rels(((ClassInstanceData *)other->get_data())->cl, l);
 
-            if ((l.findRef(r) == -1) ||
+            if ((! l.contains(r)) ||
                 (!other->is_writable() && !root_permission())) {
                 // illegal
                 com->write_ack(FALSE);

--- a/src/data/ClassInstanceData.h
+++ b/src/data/ClassInstanceData.h
@@ -75,7 +75,7 @@ private:
     BrowserClass * cl;	// type of instance
     Q3ValueList<SlotAttr> attributes;
     Q3ValueList<SlotRel> relations;
-    Q3PtrList<BasicData> connect_list;	// ClassData and ClassInstanceData
+    QList<BasicData *> connect_list;	// ClassData and ClassInstanceData
 
 protected:
     virtual void send_uml_def(ToolCom * com, BrowserNode * bn,

--- a/src/data/RelationData.cpp
+++ b/src/data/RelationData.cpp
@@ -52,10 +52,10 @@
 #include "Logging/QsLog.h"
 
 IdDict<RelationData> RelationData::all(1023, __FILE__);
-Q3PtrList<RelationData> RelationData::Unconsistent;
+QList<RelationData *> RelationData::Unconsistent;
 
 // file format < 56
-static Q3PtrList<RelationData> IncludeToHeaderIfExternal;
+static QList<RelationData *> IncludeToHeaderIfExternal;
 
 RelationData::RelationData(UmlCode e, int id)
     : Labeled<RelationData>(all, id), is_deleted(FALSE), is_unconsistent(FALSE), type(e)
@@ -1783,9 +1783,7 @@ void RelationData::set_unconsistent()
 
 void RelationData::delete_unconsistent()
 {
-    while (! Unconsistent.isEmpty()) {
-        RelationData * d = Unconsistent.take(0);
-
+    foreach (RelationData *d, Unconsistent) {
         d->SetStart(0);
         d->SetEnd(0);
         if (!d->deletedp())
@@ -1793,6 +1791,7 @@ void RelationData::delete_unconsistent()
 
         delete d;
     }
+    Unconsistent.clear();
 }
 
 // for file < 56, modify import from source to header
@@ -1800,14 +1799,13 @@ void RelationData::delete_unconsistent()
 
 void RelationData::post_load()
 {
-    while (! IncludeToHeaderIfExternal.isEmpty()) {
-        RelationData * rd = IncludeToHeaderIfExternal.take(0);
-
+    foreach (RelationData *rd, IncludeToHeaderIfExternal) {
         if ((rd->end_removed_from != 0) &&
             (rd->end_removed_from->get_type() == UmlClass) &&
             ((ClassData *) rd->end_removed_from->get_data())->cpp_is_external())
             rd->a.cpp_decl = "#include in header";
     }
+    IncludeToHeaderIfExternal.clear();
 }
 
 void RelationData::IndexStartEnd()

--- a/src/data/RelationData.h
+++ b/src/data/RelationData.h
@@ -94,7 +94,7 @@ class RelationData : public ClassMemberData, public Labeled<RelationData>
 
 protected:
     static IdDict<RelationData> all;
-    static Q3PtrList<RelationData> Unconsistent;
+    static QList<RelationData *> Unconsistent;
 
     // Uml
     bool is_deleted : 8;	// 1 useless here, 8 faster than 1 ?

--- a/src/diagram/ActivityActionCanvas.cpp
+++ b/src/diagram/ActivityActionCanvas.cpp
@@ -1043,7 +1043,7 @@ bool ActivityActionCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ActivityActionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ActivityActionCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(1);
@@ -1062,18 +1062,17 @@ void ActivityActionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                ActivityActionCanvas *canvas = (ActivityActionCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((ActivityActionCanvas *) it.current())->show_opaque_action_definition =
+                    canvas->show_opaque_action_definition =
                         show_opaque_action_definition;
 
                 if (!co[0].name.isEmpty())
-                    ((ActivityActionCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((ActivityActionCanvas *) it.current())->settings.set(st, 1);
-                ((ActivityActionCanvas *) it.current())->modified();	// call package_modified()
+                canvas->settings.set(st, 1);
+                canvas->modified();
             }
         }
 

--- a/src/diagram/ActivityActionCanvas.h
+++ b/src/diagram/ActivityActionCanvas.h
@@ -115,7 +115,7 @@ public:
     virtual void moveBy(double dx, double dy);
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/ActivityCanvas.cpp
+++ b/src/diagram/ActivityCanvas.cpp
@@ -783,7 +783,7 @@ bool ActivityCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ActivityCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ActivityCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(2);
@@ -802,19 +802,18 @@ void ActivityCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                ActivityCanvas *canvas = (ActivityCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((ActivityCanvas *) it.current())->settings.show_infonote = show_infonote;
+                    canvas->settings.show_infonote = show_infonote;
 
                 if (!st[1].name.isEmpty())
-                    ((ActivityCanvas *) it.current())->settings.drawing_language = drawing_language;
+                    canvas->settings.drawing_language = drawing_language;
 
                 if (!co[0].name.isEmpty())
-                    ((ActivityCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((ActivityCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();
             }
         }
 

--- a/src/diagram/ActivityCanvas.h
+++ b/src/diagram/ActivityCanvas.h
@@ -107,7 +107,7 @@ public:
     virtual void moveBy(double dx, double dy);
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void apply_shortcut(QString s);

--- a/src/diagram/ActivityDiagramView.cpp
+++ b/src/diagram/ActivityDiagramView.cpp
@@ -771,7 +771,6 @@ void ActivityDiagramView::save(QTextStream & st, QString & warning,
                                bool copy) const
 {
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
     if (!copy)
         // sort is useless for a copy
@@ -781,7 +780,7 @@ void ActivityDiagramView::save(QTextStream & st, QString & warning,
 
     // save first activity, activity nodes, actions, objects, packages, fragments, notes and icons
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlActivity:
         case UmlInterruptibleActivityRegion:
@@ -815,7 +814,7 @@ void ActivityDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves relations
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlFlow:
         case UmlDependOn:
@@ -829,7 +828,7 @@ void ActivityDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves anchors
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) && (di->type() == UmlAnchor))
             di->save(st, FALSE, warning);
 

--- a/src/diagram/ActivityObjectCanvas.cpp
+++ b/src/diagram/ActivityObjectCanvas.cpp
@@ -671,7 +671,7 @@ bool ActivityObjectCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ActivityObjectCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ActivityObjectCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(1);
@@ -690,18 +690,17 @@ void ActivityObjectCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                ActivityObjectCanvas *canvas = (ActivityObjectCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((ActivityObjectCanvas *) it.current())->write_horizontally =
+                    canvas->write_horizontally =
                         write_horizontally;
 
                 if (!co[0].name.isEmpty())
-                    ((ActivityObjectCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((ActivityObjectCanvas *) it.current())->settings.set(st, 1);
-                ((ActivityObjectCanvas *) it.current())->modified();	// call package_modified()
+                canvas->settings.set(st, 1);
+                canvas->modified();	// call package_modified()
             }
         }
 

--- a/src/diagram/ActivityObjectCanvas.h
+++ b/src/diagram/ActivityObjectCanvas.h
@@ -86,7 +86,7 @@ public:
     virtual void remove(bool from_model);
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void apply_shortcut(QString s);

--- a/src/diagram/ActivityPartitionCanvas.cpp
+++ b/src/diagram/ActivityPartitionCanvas.cpp
@@ -605,7 +605,7 @@ bool ActivityPartitionCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ActivityPartitionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ActivityPartitionCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -618,11 +618,10 @@ void ActivityPartitionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((ActivityPartitionCanvas *) it.current())->itscolor = itscolor;
-                ((ActivityPartitionCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                ActivityPartitionCanvas *canvas = (ActivityPartitionCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 

--- a/src/diagram/ActivityPartitionCanvas.h
+++ b/src/diagram/ActivityPartitionCanvas.h
@@ -86,7 +86,7 @@ public:
     virtual void change_scale();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/ArrowCanvas.cpp
+++ b/src/diagram/ArrowCanvas.cpp
@@ -508,12 +508,8 @@ void ArrowCanvas::go_up(double nz)
                 a->label->setZ(nz);
         }
 
-        Q3PtrListIterator<ArrowCanvas> it(a->lines);
-
-        while (it.current()) {
-            it.current()->go_up(nz);
-            ++it;
-        }
+        foreach (ArrowCanvas *canvas, a->lines)
+            canvas->go_up(nz);
 
         if ((a->end != 0) && (a->end->type() == UmlArrowPoint)) {
             if (((ArrowPointCanvas *) a->end)->z() < (nz + 1))
@@ -1343,7 +1339,7 @@ ArrowCanvas * ArrowCanvas::join(ArrowCanvas * other, ArrowPointCanvas * ap)
         end->add_line(this);	// add before remove in case end is
         end->remove_line(other, TRUE);	// an arrow junction and not del it
 
-        Q3PtrList<ArrowCanvas> olines = other->lines;
+        QList<ArrowCanvas *> olines = other->lines;
         LabelCanvas * olabel = other->label;
         LabelCanvas * ostereotype = other->stereotype;
 
@@ -1361,9 +1357,7 @@ ArrowCanvas * ArrowCanvas::join(ArrowCanvas * other, ArrowPointCanvas * ap)
         show();
 
         //gets other's lines (anchor to note)
-        while (! olines.isEmpty()) {
-            ArrowCanvas * l = olines.take();
-
+        foreach (ArrowCanvas *l, olines) {
             l->hide();
 
             if (l->begin == other)
@@ -1375,6 +1369,7 @@ ArrowCanvas * ArrowCanvas::join(ArrowCanvas * other, ArrowPointCanvas * ap)
             l->update_pos();
             l->show();
         }
+        olines.clear();
 
         //gets label and stereotype
         QFontMetrics fm(the_canvas()->get_font(UmlNormalFont));
@@ -2202,34 +2197,26 @@ void ArrowCanvas::history_hide()
 
 //
 
-Q3PtrList<ArrowCanvas> ArrowCanvas::RelsToDel;
+QList<ArrowCanvas *> ArrowCanvas::RelsToDel;
 
 void ArrowCanvas::post_load()
 {
-    while (! RelsToDel.isEmpty()) {
-        ArrowCanvas * ar = RelsToDel.take(0);
-
+    foreach (ArrowCanvas *ar, RelsToDel)
         if (ar->visible())
             ar->delete_it();
-    }
+    RelsToDel.clear();
 }
 
 // to remove redondant relation made by release 2.22
-Q3PtrList<ArrowCanvas> ArrowCanvas::RelsToCheck;
+QList<ArrowCanvas *> ArrowCanvas::RelsToCheck;
 
 void ArrowCanvas::remove_redondant_rels()
 {
-    Q3PtrListIterator<ArrowCanvas> liter(RelsToCheck);
     // the key is <source address>_<browser node address>_<target address>
     QMap<QString, ArrowCanvas *> arrows;
     char s[128];
 
-    for (;;) {
-        ArrowCanvas * r = liter.current();
-
-        if (r == 0)
-            break;
-
+    foreach (ArrowCanvas *r, RelsToCheck) {
         if (r->visible()) {
             sprintf(s, "%lx_%lx_%lx",
                     (long) r->get_start(),
@@ -2241,10 +2228,7 @@ void ArrowCanvas::remove_redondant_rels()
             else
                 arrows.insert(s, r);
         }
-
-        ++liter;
     }
-
     RelsToCheck.clear();
 }
 

--- a/src/diagram/ArrowCanvas.h
+++ b/src/diagram/ArrowCanvas.h
@@ -84,10 +84,10 @@ protected:
     float decenter_end;		// fixed geometry. < 0 means don't care
 
     // to remove temporary arrows
-    static Q3PtrList<ArrowCanvas> RelsToDel;
+    static QList<ArrowCanvas *> RelsToDel;
 
     // to remove redondant relation made by release 2.22
-    static Q3PtrList<ArrowCanvas> RelsToCheck;
+    static QList<ArrowCanvas *> RelsToCheck;
 
 public:
     ArrowCanvas(UmlCanvas * canvas, DiagramItem * b, DiagramItem * e,

--- a/src/diagram/ArrowJunctionCanvas.cpp
+++ b/src/diagram/ArrowJunctionCanvas.cpp
@@ -109,10 +109,9 @@ void ArrowJunctionCanvas::draw(QPainter & p)
     if (!visible())
         return;
 
-    ArrowCanvas * a;
     FILE * fp = svg();
 
-    for (a = lines.first(); a != 0; a = lines.next()) {
+    foreach (ArrowCanvas *a, lines) {
         switch (a->type()) {
         case UmlRequired: {
             QRect r = rect();

--- a/src/diagram/ArrowPointCanvas.cpp
+++ b/src/diagram/ArrowPointCanvas.cpp
@@ -72,7 +72,7 @@ void ArrowPointCanvas::delete_it()
 void ArrowPointCanvas::delete_available(BooL &,
                                         BooL & out_model) const
 {
-    out_model |= lines.getFirst()->may_join();
+    out_model |= lines.first()->may_join();
 }
 
 // not produced in SVG file
@@ -241,7 +241,7 @@ void ArrowPointCanvas::prepare_for_move(bool)
 
 ArrowCanvas * ArrowPointCanvas::get_other(const ArrowCanvas * l) const
 {
-    return (lines.getFirst() == l) ? lines.getLast() : lines.getFirst();
+    return (lines.first() == l) ? lines.last() : lines.first();
 }
 
 void ArrowPointCanvas::save(QTextStream & st, bool, QString &) const

--- a/src/diagram/ArtifactCanvas.cpp
+++ b/src/diagram/ArtifactCanvas.cpp
@@ -252,14 +252,10 @@ void ArtifactCanvas::draw_all_relations()
     else if (!DrawingSettings::just_modified() &&
              !on_load_diagram()) {
         // remove all association starting from 'this'
-        Q3PtrListIterator<ArrowCanvas> it(lines);
-
-        while (it.current()) {
-            if ((it.current()->type() == UmlContain) &&
-                (((AssocContainCanvas *) it.current())->get_start() == this))
-                it.current()->delete_it();
-            else
-                ++it;
+        foreach (ArrowCanvas *canvas, lines) {
+            if ((canvas->type() == UmlContain) &&
+                (((AssocContainCanvas *) canvas)->get_start() == this))
+                canvas->delete_it();
         }
 
         // update non source artifact vis a vis 'this'
@@ -287,18 +283,15 @@ void ArtifactCanvas::update_relations(ArtifactCanvas * other)
     bool association_must_exist =
         ((associated != 0) &&
          (associated->find((BrowserArtifact *) other->browser_node) != 0));
-    Q3PtrListIterator<ArrowCanvas> it(lines);
 
-    while (it.current()) {
-        if ((it.current()->type() == UmlContain) &&
-            (((AssocContainCanvas *) it.current())->get_end() == other)) {
+    foreach (ArrowCanvas *canvas, lines) {
+        if ((canvas->type() == UmlContain) &&
+            (((AssocContainCanvas *) canvas)->get_end() == other)) {
             if (! association_must_exist)
-                it.current()->delete_it();
+                canvas->delete_it();
 
             return;
         }
-
-        ++it;
     }
 
     // association not yet exist
@@ -314,12 +307,10 @@ void ArtifactCanvas::update_relations()
     const Q3PtrDict<BrowserArtifact> * associated =
         ((ArtifactData *) browser_node->get_data())->get_associated();
     Q3PtrDict<BrowserArtifact> associations;
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if ((it.current()->type() == UmlContain) &&
-            (((AssocContainCanvas *) it.current())->get_start() == this)) {
-            DiagramItem * adi = ((AssocContainCanvas *) it.current())->get_end();
+    foreach (ArrowCanvas *canvas, lines) {
+        if ((canvas->type() == UmlContain) &&
+            (((AssocContainCanvas *)canvas)->get_start() == this)) {
+            DiagramItem * adi = ((AssocContainCanvas *) canvas)->get_end();
 
             if ((adi->type() == UmlArtifact) &&
                 (associated != 0) &&
@@ -330,14 +321,11 @@ void ArtifactCanvas::update_relations()
                                       ((ArtifactCanvas *) adi)->browser_node;
 
                 associations.insert(c, c);
-                ++it;
             }
             else
                 // association must not exist
-                it.current()->delete_it();
+                canvas->delete_it();
         }
-        else
-            ++it;
     }
 
     if (associated != 0) {
@@ -787,7 +775,7 @@ bool ArtifactCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ArtifactCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ArtifactCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -800,11 +788,10 @@ void ArtifactCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((ArtifactCanvas *) it.current())->itscolor = itscolor;
-                ((ArtifactCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                ArtifactCanvas *canvas = (ArtifactCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 

--- a/src/diagram/ArtifactCanvas.h
+++ b/src/diagram/ArtifactCanvas.h
@@ -85,7 +85,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void apply_shortcut(QString s);

--- a/src/diagram/BrowserView.cpp
+++ b/src/diagram/BrowserView.cpp
@@ -399,14 +399,9 @@ void BrowserView::OnGenerateIdl()
 
 void BrowserView::OnUnmarkItem(QString name, int type)
 {
-    Q3PtrListIterator<BrowserNode> it( BrowserNode::marked_list );
-    BrowserNode *node;
-    while ( (node = it.current()) != 0 )
-    {
-        ++it;
+    foreach (BrowserNode *node, BrowserNode::marked_list)
         if(node->get_name() == name && node->get_type() == type)
             node->toggle_mark();
-    }
 }
 
 void BrowserView::OnUnmarkAll()

--- a/src/diagram/CdClassCanvas.cpp
+++ b/src/diagram/CdClassCanvas.cpp
@@ -526,32 +526,22 @@ void CdClassCanvas::post_loaded()
 
 void CdClassCanvas::check_inner()
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if (it.current()->type() == UmlInner) {
-            DiagramItem * b = ((ArrowCanvas *) it.current())->get_start();
-            DiagramItem * e = ((ArrowCanvas *) it.current())->get_end();
+    foreach (ArrowCanvas *canvas, lines) {
+        if (canvas->type() == UmlInner) {
+            DiagramItem * b = canvas->get_start();
+            DiagramItem * e = canvas->get_end();
 
             if (((BrowserNode *) b->get_bn()->parent()) != e->get_bn())
-                it.current()->delete_it();
-            else
-                ++it;
+                canvas->delete_it();
         }
-        else
-            ++it;
     }
 }
 bool CdClassCanvas::has_relation(BasicData * def) const
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if (IsaRelation(it.current()->type()) &&
-            (((RelationCanvas *) it.current())->get_data() == def))
+    foreach (ArrowCanvas *canvas, lines) {
+        if (IsaRelation(canvas->type()) &&
+            (((RelationCanvas *) canvas)->get_data() == def))
             return TRUE;
-
-        ++it;
     }
 
     return FALSE;
@@ -559,14 +549,10 @@ bool CdClassCanvas::has_relation(BasicData * def) const
 
 bool CdClassCanvas::has_inner(DiagramItem * end) const
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if ((it.current()->type() == UmlInner) &&
-            (((ArrowCanvas *) it.current())->get_end() == end))
+    foreach (ArrowCanvas *canvas, lines) {
+        if ((canvas->type() == UmlInner) &&
+            (canvas->get_end() == end))
             return TRUE;
-
-        ++it;
     }
 
     return FALSE;
@@ -1265,7 +1251,7 @@ static CdClassCanvas * container_class_without_inner(CdClassCanvas * cln)
 
 void CdClassCanvas::menu(const QPoint &)
 {
-    Q3PtrList<BrowserOperation> l =
+    QList<BrowserOperation *> l =
         ((BrowserClass *) browser_node)->inherited_operations(21);
     Q3PopupMenu m(0);
     Q3PopupMenu gensubm(0);
@@ -1344,14 +1330,11 @@ void CdClassCanvas::menu(const QPoint &)
             if (l.count() > 20)
                 m.insertItem(TR("Add inherited operation"), 2999);
             else {
-                BrowserOperation * oper;
-
                 MenuFactory::createTitle(inhopersubm, TR("Choose operation"));
                 inhopersubm.insertSeparator();
 
-                for (oper = l.first(), index = 3000;
-                     oper;
-                     oper = l.next(), index += 1) {
+                index = 3000;
+                foreach (BrowserOperation *oper, l) {
                     QString menuItemText = ((BrowserNode *) oper->parent())->get_name() +
                             QString("::") + oper->get_data()->definition(TRUE, FALSE);
                     if (((OperationData *) oper->get_data())->get_is_abstract())
@@ -1364,6 +1347,7 @@ void CdClassCanvas::menu(const QPoint &)
                     }
                     else
                         inhopersubm.insertItem(menuItemText,index);
+                    ++index;
                 }
 
                 m.insertItem(TR("Add inherited operation"), &inhopersubm);
@@ -1571,7 +1555,7 @@ void CdClassCanvas::menu(const QPoint &)
 
     case 1999: {
         OperationListDialog dialog(TR("Choose operation to edit"),
-                                   (Q3PtrList<BrowserOperation> &) operations);
+                                   (QList<BrowserOperation *> &) operations);
 
         dialog.raise();
 
@@ -1675,7 +1659,7 @@ bool CdClassCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void CdClassCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void CdClassCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st;
@@ -1692,15 +1676,14 @@ void CdClassCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                CdClassCanvas *canvas = (CdClassCanvas *)item;
                 if (!co[0].name.isEmpty())
-                    ((CdClassCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((CdClassCanvas *) it.current())->settings.set(st, 0);
-                ((CdClassCanvas *) it.current())->modified();
-                ((CdClassCanvas *) it.current())->package_modified();
+                canvas->settings.set(st, 0);
+                canvas->modified();
+                canvas->package_modified();
             }
         }
 
@@ -1836,12 +1819,10 @@ static void save_hidden_list(BrowserNode * bn, UmlCode c, QTextStream & st,
 
     bn->children(l, c);
 
-    Q3PtrListIterator<BrowserNode> it(l);
-
-    while (it.current() != 0) {
+    foreach (BrowserNode *node, l) {
         QString dummy;
 
-        if (hidden_visible.findIndex(it.current()) != -1) {
+        if (hidden_visible.findIndex(node) != -1) {
             if (s != 0) {
                 nl_indent(st);
                 st << s;
@@ -1850,10 +1831,8 @@ static void save_hidden_list(BrowserNode * bn, UmlCode c, QTextStream & st,
 
             nl_indent(st);
             st << "  ";
-            it.current()->save(st, TRUE, dummy);
+            node->save(st, TRUE, dummy);
         }
-
-        ++it;
     }
 
     if ((s != 0) && (*s == 'v')) {
@@ -1946,7 +1925,7 @@ CdClassCanvas * CdClassCanvas::read(char *& st, UmlCanvas * canvas,
                    strcmp(k, "xyz")) {
                 BrowserNode * b = BrowserAttribute::read(st, k, 0, FALSE);
 
-                if ((b != 0) && (l.findRef(b) != -1))
+                if ((b != 0) && (l.contains(b)))
                     result->hidden_visible_attributes.append(b);
             }
         }
@@ -1961,7 +1940,7 @@ CdClassCanvas * CdClassCanvas::read(char *& st, UmlCanvas * canvas,
             while (strcmp(k = read_keyword(st), "xyzwh") && strcmp(k, "xyz")) {
                 BrowserNode * b = BrowserOperation::read(st, k, 0, FALSE);
 
-                if ((b != 0) && (l.findRef(b) != -1))
+                if ((b != 0) && (l.contains(b)))
                     result->hidden_visible_operations.append(b);
             }
         }

--- a/src/diagram/CdClassCanvas.h
+++ b/src/diagram/CdClassCanvas.h
@@ -112,7 +112,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/ClassDiagramView.cpp
+++ b/src/diagram/ClassDiagramView.cpp
@@ -87,11 +87,7 @@ static bool not_yet_drawn(BrowserNode * container,
 // have marked elements not yet drawn ?
 static bool marked_not_yet_drawn(Q3PtrDict<DiagramItem> & drawn)
 {
-    const Q3PtrList<BrowserNode> & l = BrowserNode::marked_nodes();
-    Q3PtrListIterator<BrowserNode> it(l);
-    BrowserNode * bn;
-
-    for (; (bn = it.current()) != 0; ++it) {
+    foreach (BrowserNode * bn, BrowserNode::marked_nodes()) {
         UmlCode k = bn->get_type();
 
         switch (k) {
@@ -113,9 +109,7 @@ static bool marked_not_yet_drawn(Q3PtrDict<DiagramItem> & drawn)
 static void get_drawn(DiagramItemList & items,
                       Q3PtrDict<DiagramItem> & drawn)
 {
-    DiagramItem * di;
-
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem * di, items) {
         UmlCode k = di->type();
 
         switch (k) {
@@ -261,11 +255,8 @@ void ClassDiagramView::add_marked_elements(const QPoint & p,
     int x = p.x();
     int y = p.y();
     int future_y = y;
-    const Q3PtrList<BrowserNode> & l = BrowserNode::marked_nodes();
-    Q3PtrListIterator<BrowserNode> it(l);
-    BrowserNode * bn;
 
-    for (; (bn = it.current()) != 0; ++it) {
+    foreach (BrowserNode * bn, BrowserNode::marked_nodes()) {
         if (drawn[bn->get_data()] == 0) {
             DiagramCanvas * dc;
 
@@ -308,7 +299,7 @@ void ClassDiagramView::add_marked_elements(const QPoint & p,
     UmlCanvas * cnv = (UmlCanvas *) canvas();
 
     if (! cnv->must_draw_all_relations()) {
-        for (it.toFirst(); (bn = it.current()) != 0; ++it) {
+        foreach (BrowserNode * bn, BrowserNode::marked_nodes()) {
             if (drawn[bn->get_data()] == 0) {
                 UmlCode k = bn->get_type();
 
@@ -352,20 +343,18 @@ void ClassDiagramView::add_related_elements(DiagramItem  * di, QString what,
         int x = re.x();
         int y = re.bottom() + Diagram_Margin;
         int future_y = y;
-        Q3PtrListIterator<BrowserNode> it(l);
-        BrowserNode * bn;
 
-        for (; (bn = it.current()) != 0; ++it) {
-            if (drawn[bn->get_data()] == 0) {
+        foreach (BrowserNode *node, l) {
+            if (drawn[node->get_data()] == 0) {
                 DiagramCanvas * dc;
 
-                switch (bn->get_type()) {
+                switch (node->get_type()) {
                 case UmlClass:
-                    dc = new CdClassCanvas(bn, the_canvas(), x, y);
+                    dc = new CdClassCanvas(node, the_canvas(), x, y);
                     break;
 
                 case UmlPackage:
-                    dc = new PackageCanvas(bn, the_canvas(), x, y, 0);
+                    dc = new PackageCanvas(node, the_canvas(), x, y, 0);
                     break;
 
                 default:
@@ -534,7 +523,6 @@ void ClassDiagramView::save(QTextStream & st, QString & warning,
                             bool copy) const
 {
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
     if (!copy)
         // sort is useless for a copy
@@ -544,7 +532,7 @@ void ClassDiagramView::save(QTextStream & st, QString & warning,
 
     // save first the classes packages fragment notes and icons
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem * di, items) {
         switch (di->type()) {
         case UmlClass:
         case UmlNote:
@@ -564,7 +552,7 @@ void ClassDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves relations
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem * di, items) {
         if (!copy || di->copyable()) {
             UmlCode k = di->type();
 
@@ -575,7 +563,7 @@ void ClassDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves anchors
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem * di, items)
         if ((!copy || di->copyable()) && (di->type() == UmlAnchor))
             di->save(st, FALSE, warning);
 

--- a/src/diagram/CodClassInstCanvas.cpp
+++ b/src/diagram/CodClassInstCanvas.cpp
@@ -441,7 +441,7 @@ bool CodClassInstCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void CodClassInstCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void CodClassInstCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(2);
@@ -459,21 +459,20 @@ void CodClassInstCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                CodClassInstCanvas *canvas = (CodClassInstCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((CodClassInstCanvas *) it.current())->write_horizontally =
+                    canvas->write_horizontally =
                         write_horizontally;
 
                 if (!st[1].name.isEmpty())
-                    ((CodClassInstCanvas *) it.current())->show_context_mode =
+                    canvas->show_context_mode =
                         show_context_mode;
 
                 if (!co[0].name.isEmpty())
-                    ((CodClassInstCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((CodClassInstCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();	// call package_modified()
             }
         }
 
@@ -630,7 +629,7 @@ void CodClassInstCanvas::history_load(QBuffer & b)
 
 void CodClassInstCanvas::send(ToolCom * com, Q3CanvasItemList & all)
 {
-    Q3PtrList<CodClassInstCanvas> l;
+    QList<CodClassInstCanvas *> l;
     Q3CanvasItemList::Iterator cit;
 
     for (cit = all.begin(); cit != all.end(); ++cit) {
@@ -651,11 +650,7 @@ void CodClassInstCanvas::send(ToolCom * com, Q3CanvasItemList & all)
 
     com->write_unsigned(l.count());
 
-    Q3PtrListIterator<CodClassInstCanvas> it(l);
-
-    for (; it.current(); ++it) {
-        CodClassInstCanvas * i = it.current();
-
+    foreach (CodClassInstCanvas *i, l) {
         com->write_unsigned((unsigned) i->get_ident());
 
         if (i->browser_node->get_type() == UmlClass) {

--- a/src/diagram/CodClassInstCanvas.h
+++ b/src/diagram/CodClassInstCanvas.h
@@ -79,7 +79,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     virtual bool get_show_stereotype_properties() const;
 

--- a/src/diagram/CodDirsCanvas.cpp
+++ b/src/diagram/CodDirsCanvas.cpp
@@ -77,7 +77,7 @@ void CodDirsCanvas::remove_it(ColMsg * msg)
     if (unsubscribe(oper_data))
         disconnect(oper_data, 0, this, 0);
 
-    msgs.removeRef(msg);
+    msgs.remove(msg);
 }
 
 
@@ -140,19 +140,17 @@ void CodDirsCanvas::update_msgs()
     // cannot be modified in this case
     msgs.sort();
 
-    Q3PtrListIterator<ColMsg> it(msgs);
     QString nl = "\n";
     QString null;
     const QString * forward_pfix = &null;
     const QString * backward_pfix = &null;
     QString forward;
     QString backward;
-    ColMsg * msg;
     CollaborationDiagramSettings  dflt = settings;
 
     the_canvas()->browser_diagram()->get_collaborationdiagramsettings(dflt);
 
-    for (; (msg = it.current()) != 0; ++it) {
+    foreach (ColMsg *msg, msgs) {
         const BasicData * oper_data = msg->get_operation();
 
         if ((oper_data != 0) && subscribe(oper_data)) {
@@ -486,10 +484,7 @@ void CodDirsCanvas::history_load(QBuffer & b)
     ::load(angle, b);
     connect(DrawingSettings::instance(), SIGNAL(changed()), this, SLOT(modified()));
 
-    Q3PtrListIterator<ColMsg> it(msgs);
-    ColMsg * msg;
-
-    for (; (msg = it.current()) != 0; ++it) {
+    foreach (ColMsg *msg, msgs) {
         const BasicData * oper_data = msg->get_operation();
 
         if ((oper_data != 0) && subscribe(oper_data)) {
@@ -504,10 +499,7 @@ void CodDirsCanvas::history_hide()
     Q3CanvasItem::setVisible(FALSE);
     disconnect(DrawingSettings::instance(), SIGNAL(changed()), this, SLOT(modified()));
 
-    Q3PtrListIterator<ColMsg> it(msgs);
-    ColMsg * msg;
-
-    for (; (msg = it.current()) != 0; ++it) {
+    foreach (ColMsg *msg, msgs) {
         const BasicData * oper_data = msg->get_operation();
 
         if ((oper_data != 0) && unsubscribe(oper_data)) {

--- a/src/diagram/CodMsgSupport.cpp
+++ b/src/diagram/CodMsgSupport.cpp
@@ -39,16 +39,15 @@ CodMsgSupport::~CodMsgSupport()
 
 void CodMsgSupport::delete_it(ColMsgList & top)
 {
-    while (msgs.getFirst() != 0)
-        msgs.getFirst()->delete_it(FALSE, top);	// remove msg
+    while (!msgs.isEmpty())
+        msgs.first()->delete_it(FALSE, top);	// remove msg
 }
 
 bool CodMsgSupport::supports(BrowserNode * bn)
 {
     BasicData * data = bn->get_data();
-    ColMsg * msg;
 
-    for (msg = msgs.first(); msg != 0; msg = msgs.next())
+    foreach (ColMsg *msg, msgs)
         if ((BasicData *) msg->get_operation() == data)
             return TRUE;
 

--- a/src/diagram/CodObjCanvas.cpp
+++ b/src/diagram/CodObjCanvas.cpp
@@ -144,17 +144,15 @@ void CodObjCanvas::get_all_in_all_out(ColMsgList & all_in, ColMsgList & all_out)
         all_out = all_in;
     }
 
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    for (; it.current() != 0; ++it) {
+    foreach (ArrowCanvas *canvas, lines) {
         CodDirsCanvas * dirs;
 
-        if ((it.current()->type() == UmlLink) &&
-            ((dirs = ((CodLinkCanvas *) it.current())->find_dirs()) != 0)) {
+        if ((canvas->type() == UmlLink) &&
+            ((dirs = ((CodLinkCanvas *) canvas)->find_dirs()) != 0)) {
             CodObjCanvas * from;
             CodObjCanvas * to;
 
-            ((CodLinkCanvas *) it.current())->get_start_end(from, to);
+            ((CodLinkCanvas *) canvas)->get_start_end(from, to);
 
             if (this == to)
                 ColMsg::get_all_in_all_out(all_in, all_out, dirs->get_msgs());
@@ -170,4 +168,3 @@ CodObjCanvas * CodObjCanvas::read(char *& st, UmlCanvas * canvas)
 
     return CodClassInstCanvas::read(st, canvas, k);
 }
-

--- a/src/diagram/CodSelfLinkCanvas.cpp
+++ b/src/diagram/CodSelfLinkCanvas.cpp
@@ -85,7 +85,7 @@ void CodSelfLinkCanvas::remove_it(ColMsg * msg)
     if (unsubscribe(oper_data))
         disconnect(oper_data, 0, this, 0);
 
-    msgs.removeRef(msg);
+    msgs.remove(msg);
 }
 
 void CodSelfLinkCanvas::delete_available(BooL &, BooL & out_model) const
@@ -166,23 +166,22 @@ void CodSelfLinkCanvas::update_msgs()
 
         the_canvas()->browser_diagram()->get_collaborationdiagramsettings(dflt);
 
-        Q3PtrListIterator<ColMsg> it(msgs);
         QString nl = "\n";
         QString null;
         const QString * pfix = &null;
 
-        for (; it.current() != 0; ++it) {
-            const BasicData * oper_data = it.current()->get_operation();
+        foreach (ColMsg *msg, msgs) {
+            const BasicData *oper_data = msg->get_operation();
 
             if ((oper_data != 0) && subscribe(oper_data)) {
                 connect(oper_data, SIGNAL(changed()), this, SLOT(modified()));
                 connect(oper_data, SIGNAL(deleted()), this, SLOT(modified()));
             }
 
-            QString m = it.current()->def(dflt.show_hierarchical_rank == UmlYes,
-                                          dflt.show_full_operations_definition == UmlYes,
-                                          dflt.drawing_language,
-                                          dflt.show_msg_context_mode);
+            QString m = msg->def(dflt.show_hierarchical_rank == UmlYes,
+                                 dflt.show_full_operations_definition == UmlYes,
+                                 dflt.drawing_language,
+                                 dflt.show_msg_context_mode);
 
             if (!m.isEmpty()) {
                 s += *pfix + m;
@@ -449,10 +448,8 @@ void CodSelfLinkCanvas::history_load(QBuffer & b)
     ::load(delta_y, b);
     ::load(angle, b);
 
-    Q3PtrListIterator<ColMsg> it(msgs);
-
-    for (; it.current() != 0; ++it) {
-        const BasicData * oper_data = it.current()->get_operation();
+    foreach (ColMsg *msg, msgs) {
+        const BasicData *oper_data = msg->get_operation();
 
         if ((oper_data != 0) && subscribe(oper_data)) {
             connect(oper_data, SIGNAL(changed()), this, SLOT(modified()));
@@ -466,13 +463,10 @@ void CodSelfLinkCanvas::history_hide()
     DiagramCanvas::setVisible(FALSE);
     disconnect(DrawingSettings::instance(), SIGNAL(changed()), this, SLOT(modified()));
 
-    Q3PtrListIterator<ColMsg> it(msgs);
-
-    for (; it.current() != 0; ++it) {
-        const BasicData * oper_data = it.current()->get_operation();
+    foreach (ColMsg *msg, msgs) {
+        const BasicData * oper_data = msg->get_operation();
 
         if ((oper_data != 0) && unsubscribe(oper_data))
             disconnect(oper_data, 0, this, 0);
     }
 }
-

--- a/src/diagram/ColDiagramView.cpp
+++ b/src/diagram/ColDiagramView.cpp
@@ -321,7 +321,6 @@ void ColDiagramView::save(QTextStream & st, QString & warning,
                           bool copy) const
 {
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
     if (!copy)
         // sort is useless for a copy
@@ -331,7 +330,7 @@ void ColDiagramView::save(QTextStream & st, QString & warning,
 
     // save first the packages fragment, classes instances, notes, icons and text
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlPackage:
         case UmlFragment:
@@ -352,7 +351,7 @@ void ColDiagramView::save(QTextStream & st, QString & warning,
 
     // then save links selflink and dirs (without messages)
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlLink:	// saves associated dirs
         case UmlSelfLink:
@@ -370,7 +369,7 @@ void ColDiagramView::save(QTextStream & st, QString & warning,
 
     // then save anchors
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) && (di->type() == UmlAnchor))
             di->save(st, FALSE, warning);
 

--- a/src/diagram/ColMsg.h
+++ b/src/diagram/ColMsg.h
@@ -48,10 +48,12 @@ class ColMsg;
 //[lgfreitas] q3ptrlist needed
 #include <q3ptrlist.h>
 
-class ColMsgList : public Q3PtrList<ColMsg>
+class ColMsgList : public QList<ColMsg *>
 {
+public:
+    void sort();
 protected:
-    virtual int compareItems(Q3PtrCollection::Item item1, Q3PtrCollection::Item item2);
+    static bool compareItems(ColMsg *a, ColMsg *b);
 };
 
 

--- a/src/diagram/ComponentCanvas.cpp
+++ b/src/diagram/ComponentCanvas.cpp
@@ -342,17 +342,9 @@ void ComponentCanvas::modified()
     check_stereotypeproperties();
 
     // remove required/provided arrow if needed
-    ArrowCanvas * a = lines.first();
-
-    while (a != 0) {
-        if (! valid(a)) {
-            // class removed from required/provided
-            a->delete_it();
-            a = lines.current();
-        }
-        else
-            a = lines.next();
-    }
+    foreach (ArrowCanvas *a, lines)
+        if (! valid(a))
+            a->delete_it(); // class removed from required/provided
 
     if (the_canvas()->must_draw_all_relations())
         draw_all_simple_relations();
@@ -1023,7 +1015,7 @@ bool ComponentCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ComponentCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ComponentCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(4);
@@ -1043,25 +1035,25 @@ void ComponentCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         SettingsDialog dialog(&st, &co, FALSE, TRUE);
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
 
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                ComponentCanvas *canvas = (ComponentCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((ComponentCanvas *) it.current())->settings.draw_component_as_icon = draw_component_as_icon;
+                    canvas->settings.draw_component_as_icon = draw_component_as_icon;
 
                 if (!st[1].name.isEmpty())
-                    ((ComponentCanvas *) it.current())->settings.show_component_req_prov = show_component_req_prov;
+                    canvas->settings.show_component_req_prov = show_component_req_prov;
 
                 if (!st[2].name.isEmpty())
-                    ((ComponentCanvas *) it.current())->settings.show_component_rea = show_component_rea;
+                    canvas->settings.show_component_rea = show_component_rea;
 
                 if (!st[3].name.isEmpty())
-                    ((ComponentCanvas *) it.current())->settings.show_stereotype_properties = show_stereotype_properties;
+                    canvas->settings.show_stereotype_properties = show_stereotype_properties;
 
                 if (!co[0].name.isEmpty())
-                    ((ComponentCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((ComponentCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();
             }
         }
 

--- a/src/diagram/ComponentCanvas.h
+++ b/src/diagram/ComponentCanvas.h
@@ -100,7 +100,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/ComponentDiagramView.cpp
+++ b/src/diagram/ComponentDiagramView.cpp
@@ -68,11 +68,7 @@ ComponentDiagramView::ComponentDiagramView(QWidget * parent, UmlCanvas * canvas,
 // have marked elements not yet drawn ?
 static bool marked_not_yet_drawn(Q3PtrDict<DiagramItem> & drawn)
 {
-    const Q3PtrList<BrowserNode> & l = BrowserNode::marked_nodes();
-    Q3PtrListIterator<BrowserNode> it(l);
-    BrowserNode * bn;
-
-    for (; (bn = it.current()) != 0; ++it) {
+    foreach (BrowserNode *bn, BrowserNode::marked_nodes()) {
         UmlCode k = bn->get_type();
 
         switch (k) {
@@ -94,9 +90,7 @@ static bool marked_not_yet_drawn(Q3PtrDict<DiagramItem> & drawn)
 static void get_drawn(DiagramItemList & items,
                       Q3PtrDict<DiagramItem> & drawn)
 {
-    DiagramItem * di;
-
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         UmlCode k = di->type();
 
         switch (k) {
@@ -164,11 +158,8 @@ void ComponentDiagramView::add_marked_elements(const QPoint & p,
     int x = p.x();
     int y = p.y();
     int future_y = y;
-    const Q3PtrList<BrowserNode> & l = BrowserNode::marked_nodes();
-    Q3PtrListIterator<BrowserNode> it(l);
-    BrowserNode * bn;
 
-    for (; (bn = it.current()) != 0; ++it) {
+    foreach (BrowserNode *bn, BrowserNode::marked_nodes()) {
         if (drawn[bn->get_data()] == 0) {
             DiagramCanvas * dc;
 
@@ -211,7 +202,7 @@ void ComponentDiagramView::add_marked_elements(const QPoint & p,
     UmlCanvas * cnv = (UmlCanvas *) canvas();
 
     if (! cnv->must_draw_all_relations()) {
-        for (it.toFirst(); (bn = it.current()) != 0; ++it) {
+        foreach (BrowserNode *bn, BrowserNode::marked_nodes()) {
             if ((drawn[bn->get_data()] == 0) &&
                 IsaSimpleRelation(bn->get_type()))
                 SimpleRelationCanvas::drop(bn, cnv, drawn);
@@ -249,10 +240,7 @@ void ComponentDiagramView::add_related_elements(DiagramItem  * di, QString what,
         int x = re.x();
         int y = re.bottom() + Diagram_Margin;
         int future_y = y;
-        Q3PtrListIterator<BrowserNode> it(l);
-        BrowserNode * bn;
-
-        for (; (bn = it.current()) != 0; ++it) {
+        foreach (BrowserNode *bn, l) {
             if (drawn[bn->get_data()] == 0) {
                 DiagramCanvas * dc;
 
@@ -422,7 +410,6 @@ void ComponentDiagramView::save(QTextStream & st, QString & warning,
                                 bool copy) const
 {
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
     if (!copy)
         // sort is useless for a copy
@@ -432,7 +419,7 @@ void ComponentDiagramView::save(QTextStream & st, QString & warning,
 
     // save first component packages fragment notes junctions and icons
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlComponent:
         case UmlNote:
@@ -453,7 +440,7 @@ void ComponentDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves relations
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlInherit:
         case UmlDependency:
@@ -470,7 +457,7 @@ void ComponentDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves anchors
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) && (di->type() == UmlAnchor))
             di->save(st, FALSE, warning);
 

--- a/src/diagram/ConstraintCanvas.cpp
+++ b/src/diagram/ConstraintCanvas.cpp
@@ -245,7 +245,7 @@ bool ConstraintCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ConstraintCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ConstraintCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -258,11 +258,10 @@ void ConstraintCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((ConstraintCanvas *) it.current())->itscolor = itscolor;
-                ((ConstraintCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                ConstraintCanvas *canvas = (ConstraintCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 
@@ -292,11 +291,10 @@ ConstraintCanvas::compute(UmlCanvas * canvas,
 
     QString s;
     QString constraint;
-    BrowserNode * bn;
 
     if (current == 0) {
         // get all
-        for (bn = elts.first(); bn != 0; bn = elts.next()) {
+        foreach (BrowserNode *bn, elts) {
             if (bn->get_type() == UmlClass)
                 // change on class's members modify class => memorize classes only
                 list.append(bn->get_data());
@@ -310,7 +308,7 @@ ConstraintCanvas::compute(UmlCanvas * canvas,
     else if (current->indicate_visible) {
         Q3ValueList<BrowserNode *> & visible = current->hidden_visible;
 
-        for (bn = elts.first(); bn != 0; bn = elts.next()) {
+        foreach (BrowserNode *bn, elts) {
             if (visible.findIndex(bn) != -1) {
                 if (bn->get_type() == UmlClass)
                     // change on class's members modify class => memorize classes only
@@ -326,7 +324,7 @@ ConstraintCanvas::compute(UmlCanvas * canvas,
     else {
         Q3ValueList<BrowserNode *> & hidden = current->hidden_visible;
 
-        for (bn = elts.first(); bn != 0; bn = elts.next()) {
+        foreach (BrowserNode *bn, elts) {
             if (hidden.findIndex(bn) == -1) {
                 if (bn->get_type() == UmlClass)
                     // change on class's members modify class => memorize classes only

--- a/src/diagram/ConstraintCanvas.h
+++ b/src/diagram/ConstraintCanvas.h
@@ -67,7 +67,7 @@ public:
 
     virtual void apply_shortcut(QString s);
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void save(QTextStream  & st, bool ref, QString & warning) const;

--- a/src/diagram/DeploymentDiagramView.cpp
+++ b/src/diagram/DeploymentDiagramView.cpp
@@ -73,11 +73,7 @@ DeploymentDiagramView::DeploymentDiagramView(QWidget * parent, UmlCanvas * canva
 // have marked elements not yet drawn ?
 static bool marked_not_yet_drawn(Q3PtrDict<DiagramItem> & drawn)
 {
-    const Q3PtrList<BrowserNode> & l = BrowserNode::marked_nodes();
-    Q3PtrListIterator<BrowserNode> it(l);
-    BrowserNode * bn;
-
-    for (; (bn = it.current()) != 0; ++it) {
+    foreach (BrowserNode *bn, BrowserNode::marked_nodes()) {
         UmlCode k = bn->get_type();
 
         switch (k) {
@@ -101,9 +97,7 @@ static bool marked_not_yet_drawn(Q3PtrDict<DiagramItem> & drawn)
 static void get_drawn(DiagramItemList & items,
                       Q3PtrDict<DiagramItem> & drawn)
 {
-    DiagramItem * di;
-
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         UmlCode k = di->type();
 
         switch (k) {
@@ -173,11 +167,8 @@ void DeploymentDiagramView::add_marked_elements(const QPoint & p,
     int x = p.x();
     int y = p.y();
     int future_y = y;
-    const Q3PtrList<BrowserNode> & l = BrowserNode::marked_nodes();
-    Q3PtrListIterator<BrowserNode> it(l);
-    BrowserNode * bn;
 
-    for (; (bn = it.current()) != 0; ++it) {
+    foreach (BrowserNode *bn, BrowserNode::marked_nodes()) {
         if (drawn[bn->get_data()] == 0) {
             DiagramCanvas * dc;
 
@@ -228,7 +219,7 @@ void DeploymentDiagramView::add_marked_elements(const QPoint & p,
     UmlCanvas * cnv = (UmlCanvas *) canvas();
 
     if (! cnv->must_draw_all_relations()) {
-        for (it.toFirst(); (bn = it.current()) != 0; ++it) {
+        foreach (BrowserNode *bn, BrowserNode::marked_nodes()) {
             if ((drawn[bn->get_data()] == 0) &&
                 IsaSimpleRelation(bn->get_type()))
                 SimpleRelationCanvas::drop(bn, cnv, drawn);
@@ -266,10 +257,8 @@ void DeploymentDiagramView::add_related_elements(DiagramItem * di, QString what,
         int x = re.x();
         int y = re.bottom() + Diagram_Margin;
         int future_y = y;
-        Q3PtrListIterator<BrowserNode> it(l);
-        BrowserNode * bn;
 
-        for (; (bn = it.current()) != 0; ++it) {
+        foreach (BrowserNode *bn, l) {
             if (drawn[bn->get_data()] == 0) {
                 DiagramCanvas * dc;
 
@@ -535,7 +524,6 @@ void DeploymentDiagramView::save(QTextStream & st, QString & warning,
                                  bool copy) const
 {
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
     if (!copy)
         // sort is useless for a copy
@@ -545,7 +533,7 @@ void DeploymentDiagramView::save(QTextStream & st, QString & warning,
 
     // save first package fragment deploymentnode component hub notes text and icons
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlDeploymentNode:
         case UmlArtifact:
@@ -568,7 +556,7 @@ void DeploymentDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves relations
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlInherit:
         case UmlDependency:
@@ -585,7 +573,7 @@ void DeploymentDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves anchors
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) && (di->type() == UmlAnchor))
             di->save(st, FALSE, warning);
 

--- a/src/diagram/DeploymentNodeCanvas.cpp
+++ b/src/diagram/DeploymentNodeCanvas.cpp
@@ -619,7 +619,7 @@ bool DeploymentNodeCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void DeploymentNodeCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void DeploymentNodeCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(2);
@@ -637,21 +637,20 @@ void DeploymentNodeCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                DeploymentNodeCanvas *canvas = (DeploymentNodeCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((DeploymentNodeCanvas *) it.current())->write_horizontally =
+                    canvas->write_horizontally =
                         write_horizontally;
 
                 if (!st[1].name.isEmpty())
-                    ((DeploymentNodeCanvas *) it.current())->show_stereotype_properties =
+                    canvas->show_stereotype_properties =
                         show_stereotype_properties;
 
                 if (!co[0].name.isEmpty())
-                    ((DeploymentNodeCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((DeploymentNodeCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();
             }
         }
 

--- a/src/diagram/DeploymentNodeCanvas.h
+++ b/src/diagram/DeploymentNodeCanvas.h
@@ -95,7 +95,7 @@ public:
     virtual void set_type(BrowserNode * t);
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/DiagramCanvas.cpp
+++ b/src/diagram/DiagramCanvas.cpp
@@ -195,15 +195,10 @@ void DiagramCanvas::moveBy(double dx, double dy)
 
 void DiagramCanvas::moveSelfRelsBy(double dx, double dy)
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if (it.current()->get_start() == it.current()->get_end())
+    foreach (ArrowCanvas *canvas, lines)
+        if (canvas->get_start() == canvas->get_end())
             // self relation
-            it.current()->move_self_points(dx, dy); // move only if first segment => not done 2 times
-
-        ++it;
-    }
+            canvas->move_self_points(dx, dy); // move only if first segment => not done 2 times
 }
 
 void DiagramCanvas::setSelected(bool yes)
@@ -426,14 +421,10 @@ void DiagramCanvas::prepare_for_move(bool on_resize)
 {
     if (! on_resize) {
         // select self relations
-        Q3PtrListIterator<ArrowCanvas> it(lines);
-
-        while (it.current()) {
-            if (it.current()->get_start() == it.current()->get_end())
+        foreach (ArrowCanvas *canvas, lines) {
+            if (canvas->get_start() == canvas->get_end())
                 // note : selected 2 times (from the start and the end)
-                it.current()->select_associated();
-
-            ++it;
+                canvas->select_associated();
         }
     }
 }
@@ -452,7 +443,6 @@ bool DiagramCanvas::move_with(UmlCode k) const
 
 void DiagramCanvas::force_self_rel_visible()
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
     QRect r = rect();
 
     // add a marging
@@ -461,12 +451,10 @@ void DiagramCanvas::force_self_rel_visible()
     r.setTop(r.top() - 5);
     r.setBottom(r.bottom() + 5);
 
-    while (it.current()) {
-        if (it.current()->get_start() == it.current()->get_end())
+    foreach (ArrowCanvas *canvas, lines) {
+        if (canvas->get_start() == canvas->get_end())
             // self relation
-            it.current()->move_outside(r);
-
-        ++it;
+            canvas->move_outside(r);
     }
 }
 
@@ -490,11 +478,8 @@ void DiagramCanvas::upper()
 
         nz += 1;
 
-        Q3PtrListIterator<ArrowCanvas> it(lines);
-
-        while (it.current()) {
-            it.current()->go_up(nz);
-            ++it;
+        foreach (ArrowCanvas *canvas, lines) {
+            canvas->go_up(nz);
         }
     }
 }
@@ -564,12 +549,8 @@ void DiagramCanvas::z_up()
 
         set_z(next_z);
 
-        Q3PtrListIterator<ArrowCanvas> it(lines);
-
-        while (it.current()) {
-            it.current()->go_up(next_z);
-            ++it;
-        }
+        foreach (ArrowCanvas *canvas, lines)
+            canvas->go_up(next_z);
     }
 }
 
@@ -836,14 +817,10 @@ double DiagramCanvas::compute_angle(double delta_x, double delta_y)
 
 bool DiagramCanvas::has_simple_relation(BasicData * def) const
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if (IsaSimpleRelation(it.current()->type()) &&
-            (((SimpleRelationCanvas *) it.current())->get_data() == def))
+    foreach (ArrowCanvas *canvas, lines) {
+        if (IsaSimpleRelation(canvas->type()) &&
+            (((SimpleRelationCanvas *) canvas)->get_data() == def))
             return TRUE;
-
-        ++it;
     }
 
     return FALSE;
@@ -913,14 +890,10 @@ void DiagramCanvas::draw_all_simple_relations(DiagramCanvas * end)
 
 bool DiagramCanvas::has_flow(BasicData * def) const
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if ((it.current()->type() == UmlFlow) &&
-            (((FlowCanvas *) it.current())->get_data() == def))
+    foreach (ArrowCanvas *canvas, lines) {
+        if ((canvas->type() == UmlFlow) &&
+            (((FlowCanvas *) canvas)->get_data() == def))
             return TRUE;
-
-        ++it;
     }
 
     return FALSE;
@@ -989,14 +962,10 @@ void DiagramCanvas::draw_all_flows(DiagramCanvas * end)
 
 bool DiagramCanvas::has_transition(BasicData * def) const
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if ((it.current()->type() == UmlTransition) &&
-            (((TransitionCanvas *) it.current())->get_data() == def))
+    foreach (ArrowCanvas *canvas, lines) {
+        if ((canvas->type() == UmlTransition) &&
+            (((TransitionCanvas *) canvas)->get_data() == def))
             return TRUE;
-
-        ++it;
     }
 
     return FALSE;

--- a/src/diagram/DiagramItem.cpp
+++ b/src/diagram/DiagramItem.cpp
@@ -43,7 +43,7 @@
 #include "myio.h"
 #include "translate.h"
 
-Q3PtrList<DiagramItem> DiagramItem::Undefined;
+QList<DiagramItem *> DiagramItem::Undefined;
 
 DiagramItem::DiagramItem(int id, UmlCanvas * canvas)
     : Labeled<DiagramItem>(canvas->get_all_items(), id)
@@ -70,20 +70,16 @@ void DiagramItem::remove(bool)
 
 void DiagramItem::hide_lines()
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    for (; it.current(); ++it)
-        it.current()->hide();
+    foreach (ArrowCanvas *canvas, lines)
+        canvas->hide();
 }
 
 void DiagramItem::update_show_lines()
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    for (; it.current(); ++it) {
-        it.current()->update_pos();
-        it.current()->show();
-        it.current()->update_geometry();
+    foreach (ArrowCanvas *canvas, lines) {
+        canvas->update_pos();
+        canvas->show();
+        canvas->update_geometry();
     }
 }
 
@@ -99,10 +95,8 @@ void DiagramItem::check_line(ArrowCanvas *)
 
 bool DiagramItem::attached_to(const ArrowCanvas * l) const
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    for (; it.current(); ++it)
-        if (it.current() == l)
+    foreach (ArrowCanvas *canvas, lines)
+        if (canvas == l)
             return TRUE;
 
     return FALSE;
@@ -188,8 +182,9 @@ void DiagramItem::remove_if_already_present()
 
 void DiagramItem::post_load()
 {
-    while (! Undefined.isEmpty())
-        Undefined.take()->delete_it();
+    foreach (DiagramItem *item, Undefined)
+        item->delete_it();
+    Undefined.clear();
 }
 
 BasicData * DiagramItem::add_relation(UmlCode t, DiagramItem * end)
@@ -208,29 +203,18 @@ BasicData * DiagramItem::add_relation(UmlCode t, DiagramItem * end)
 bool DiagramItem::has_relation(BasicData * def) const
 {
     // manage only SimpleRelations
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if (IsaSimpleRelation(it.current()->type()) &&
-            (it.current()->get_data() == def))
+    foreach (ArrowCanvas *canvas, lines)
+        if (IsaSimpleRelation(canvas->type()) && (canvas->get_data() == def))
             return TRUE;
-
-        ++it;
-    }
 
     return FALSE;
 }
 
 bool DiagramItem::has_relation(UmlCode t, BasicData * def) const
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if ((it.current()->type() == t) &&
-            (it.current()->get_data() == def))
+    foreach (ArrowCanvas *canvas, lines) {
+        if ((canvas->type() == t) && (canvas->get_data() == def))
             return TRUE;
-
-        ++it;
     }
 
     return FALSE;
@@ -253,10 +237,8 @@ bool DiagramItem::move_with(UmlCode) const
 
 void DiagramItem::select_associated()
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    for (; it.current(); ++it)
-        it.current()->select_associated();
+    foreach (ArrowCanvas *canvas, lines)
+        canvas->select_associated();
 }
 
 void DiagramItem::unassociate(DiagramItem *)
@@ -400,13 +382,14 @@ bool DiagramItem::has_drawing_settings() const
     return FALSE;
 }
 
-void DiagramItem::edit_drawing_settings(Q3PtrList<DiagramItem> &)
+void DiagramItem::edit_drawing_settings(QList<DiagramItem *> &)
 {
     // never called
 }
 
 void DiagramItem::clone_drawing_settings(const DiagramItem *src)
 {
+    Q_UNUSED(src);
     // never called
 }
 
@@ -437,11 +420,13 @@ DiagramItemList::~DiagramItemList()
 {
 }
 
-int DiagramItemList::compareItems(Q3PtrCollection::Item i1,
-                                  Q3PtrCollection::Item i2)
+void DiagramItemList::sort()
 {
-    // i1 <> i2 !
-    return (((DiagramItem *) i1)->get_ident() >
-            ((DiagramItem *) i2)->get_ident())
-           ? 1 : -1;
+    qSort(begin(), end(), lessThan);
+}
+
+bool DiagramItemList::lessThan(DiagramItem *a, DiagramItem *b)
+{
+    // a <> b !
+    return a->get_ident() > b->get_ident();
 }

--- a/src/diagram/DiagramItem.h
+++ b/src/diagram/DiagramItem.h
@@ -58,9 +58,9 @@ class UmlCanvas;
 class DiagramItem : public Labeled<DiagramItem>
 {
 protected:
-    Q3PtrList<ArrowCanvas> lines;
+    QList<ArrowCanvas *> lines;
 
-    static Q3PtrList<DiagramItem> Undefined;
+    static QList<DiagramItem *> Undefined;
 
 public:
     DiagramItem(int id, UmlCanvas * canvas);
@@ -133,7 +133,7 @@ public:
     }
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void apply_shortcut(QString);
@@ -146,12 +146,14 @@ public:
     virtual bool represents(BrowserNode *);
 };
 
-class DiagramItemList : public Q3PtrList<DiagramItem>
+class DiagramItemList : public QList<DiagramItem *>
 {
 public:
     DiagramItemList(Q3CanvasItemList);
     virtual ~DiagramItemList();
-    virtual int compareItems(Q3PtrCollection::Item, Q3PtrCollection::Item);
+
+    void sort();
+    static bool lessThan(DiagramItem *a, DiagramItem *b);
 };
 
 

--- a/src/diagram/DiagramView.cpp
+++ b/src/diagram/DiagramView.cpp
@@ -113,8 +113,6 @@ DiagramView::DiagramView(QWidget * parent, UmlCanvas * canvas, int i)
     canvas->setDoubleBuffering(TRUE);
 
     canvas->set_view(this);
-
-    history.setAutoDelete(TRUE);
 }
 
 void DiagramView::init()
@@ -148,7 +146,7 @@ void DiagramView::contentsMouseDoubleClickEvent(QMouseEvent * e)
 
 bool DiagramView::multiple_selection_for_menu(BooL & in_model, BooL & out_model,
         BooL & alignable, int & n_resize,
-        Q3PtrList<DiagramItem> & l_drawing_settings,
+        QList<DiagramItem *> & l_drawing_settings,
         const Q3CanvasItemList & selected)
 {
     Q3CanvasItemList::ConstIterator it;
@@ -223,7 +221,7 @@ void DiagramView::contentsMousePressEvent(QMouseEvent * e)
                 BooL in_model;
                 BooL out_model;
                 BooL alignable;
-                Q3PtrList<DiagramItem> l_drawing_settings;
+                QList<DiagramItem *> l_drawing_settings;
                 int n_resize;
 
                 if (multiple_selection_for_menu(in_model, out_model, alignable,
@@ -1007,7 +1005,7 @@ void DiagramView::same_size(bool w, bool h)
 
 void DiagramView::multiple_selection_menu(bool in_model, bool out_model,
         bool alignable, int n_resize,
-        Q3PtrList<DiagramItem> & l_drawing_settings)
+        QList<DiagramItem *> & l_drawing_settings)
 {
     const Q3CanvasItemList selected = selection();
     Q3CanvasItemList::ConstIterator it;
@@ -1158,12 +1156,12 @@ void DiagramView::multiple_selection_menu(bool in_model, bool out_model,
         same_size(TRUE, TRUE);
         break;
 
-    case 17: {
+    case 17:
         history_protected = FALSE;
-        Q3PtrListIterator<DiagramItem> it(l_drawing_settings);
-        const DiagramItem *source = it.current();
-        while (++it, it.current() != 0)
-            it.current()->clone_drawing_settings(source);
+        if (!l_drawing_settings.isEmpty()) {
+            const DiagramItem *source = l_drawing_settings[0];
+            for (int i = 1, n = l_drawing_settings.size(); i < n; ++i)
+                l_drawing_settings[i]->clone_drawing_settings(source);
         }
 
     default:
@@ -1433,7 +1431,7 @@ void DiagramView::keyPressEvent(QKeyEvent * e)
                              (s == "Same drawing settings")) {
                         Q3CanvasItemList::ConstIterator it;
                         UmlCode k = UmlCodeSup;
-                        Q3PtrList<DiagramItem> l;
+                        QList<DiagramItem *> l;
 
                         for (it = selected.begin(); it != selected.end(); ++it) {
                             if (! isa_label(*it)) {
@@ -1481,10 +1479,11 @@ void DiagramView::keyPressEvent(QKeyEvent * e)
                                 l.first()->edit_drawing_settings(l);
                             else {
                                 history_protected = FALSE;
-                                Q3PtrListIterator<DiagramItem> it(l);
-                                const DiagramItem *source = it.current();
-                                while (++it, it.current() != 0)
-                                    it.current()->clone_drawing_settings(source);
+                                if (!l.isEmpty()) {
+                                    const DiagramItem *source = l[0];
+                                    for (int i = 1, n = l.size(); i < n; ++i)
+                                        l[i]->clone_drawing_settings(source);
+                                }
                             }
                         }
                     }
@@ -1542,7 +1541,7 @@ void DiagramView::keyPressEvent(QKeyEvent * e)
                         BooL in_model;
                         BooL out_model;
                         BooL alignable;
-                        Q3PtrList<DiagramItem> l_drawing_settings;
+                        QList<DiagramItem *> l_drawing_settings;
                         int n_resize;
 
                         if (multiple_selection_for_menu(in_model, out_model, alignable,
@@ -2659,8 +2658,8 @@ void DiagramView::history_save(bool on_undo)
         return;
 
     // get current state
-    QByteArray * ba = new QByteArray();
-    QBuffer b(ba);
+    QByteArray ba;
+    QBuffer b(&ba);
 
     b.open(QIODevice::WriteOnly);
 
@@ -2671,10 +2670,10 @@ void DiagramView::history_save(bool on_undo)
     */
 
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem * di, items) {
         di->history_save(b);
+    }
 
     b.close();
 
@@ -2684,19 +2683,15 @@ void DiagramView::history_save(bool on_undo)
         history_index = 0;
     }
     else {
-        QByteArray * current = history.at(history_index);
+        const QByteArray &current = history.at(history_index);
 
         if (! on_undo) {
             // remove redo
-            while (history.getLast() != current)
+            while (history.last() != current)
                 history.removeLast();
         }
 
-        if (*ba == *current) {
-            // nothing new
-            delete ba;
-        }
-        else {
+        if (ba != current) {
             history.append(ba);
 
             // limit history depth to 20
@@ -2717,15 +2712,14 @@ void DiagramView::history_load()
     unselect_all();
 
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
-
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         di->history_hide();
         di->post_history_hide();
     }
 
     // load history
-    QBuffer b((history.at(history_index))); // [lgfreitas] now qbuffer receives a pointer to a bytearray
+    QByteArray &ba = history[history_index];
+    QBuffer b(&ba); // [lgfreitas] now qbuffer receives a pointer to a bytearray
 
     b.open(QIODevice::ReadOnly);
 

--- a/src/diagram/DiagramView.h
+++ b/src/diagram/DiagramView.h
@@ -78,7 +78,7 @@ protected:
     BooL decenter_start;
     BooL decenter_horiz;
     Q3ValueList<QPoint> previousResizeCorrection;
-    Q3PtrList<QByteArray> history;
+    QList<QByteArray> history;
     unsigned history_index;
 
 
@@ -112,7 +112,7 @@ public:
         return preferred_zoom != 0;
     }
     void multiple_selection_menu(bool in_model, bool out_model, bool alignable,
-                                 int n_resize, Q3PtrList<DiagramItem> & l_drawing_settings);
+                                 int n_resize, QList<DiagramItem *> & l_drawing_settings);
     bool is_present(BrowserNode * bn);
     virtual void add_related_elements(DiagramItem *, QString what,
                                       bool inh, bool assoc);
@@ -175,7 +175,7 @@ protected:
     void add_point(QMouseEvent * e);
     bool multiple_selection_for_menu(BooL & in_model, BooL & out_model,
                                      BooL & alignable, int & n_resize,
-                                     Q3PtrList<DiagramItem> & l_drawing_settings,
+                                     QList<DiagramItem *> & l_drawing_settings,
                                      const Q3CanvasItemList & selected);
 
     void set_format(int);

--- a/src/diagram/ExpansionNodeCanvas.cpp
+++ b/src/diagram/ExpansionNodeCanvas.cpp
@@ -443,7 +443,7 @@ bool ExpansionNodeCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ExpansionNodeCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ExpansionNodeCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -456,11 +456,10 @@ void ExpansionNodeCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((ExpansionNodeCanvas *) it.current())->itscolor = itscolor;
-                ((ExpansionNodeCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                ExpansionNodeCanvas *canvas = (ExpansionNodeCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();	// call package_modified()
             }
         }
 

--- a/src/diagram/ExpansionNodeCanvas.h
+++ b/src/diagram/ExpansionNodeCanvas.h
@@ -82,7 +82,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/ExpansionRegionCanvas.cpp
+++ b/src/diagram/ExpansionRegionCanvas.cpp
@@ -612,7 +612,7 @@ bool ExpansionRegionCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ExpansionRegionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ExpansionRegionCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -625,11 +625,10 @@ void ExpansionRegionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((ExpansionRegionCanvas *) it.current())->itscolor = itscolor;
-                ((ExpansionRegionCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                ExpansionRegionCanvas *canvas = (ExpansionRegionCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 

--- a/src/diagram/ExpansionRegionCanvas.h
+++ b/src/diagram/ExpansionRegionCanvas.h
@@ -106,7 +106,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/FlowCanvas.cpp
+++ b/src/diagram/FlowCanvas.cpp
@@ -420,7 +420,7 @@ bool FlowCanvas::has_drawing_settings() const
     return ((aplabel != 0) || (apstereotype != 0));
 }
 
-void FlowCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void FlowCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(1);
@@ -436,16 +436,15 @@ void FlowCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                FlowCanvas *canvas = (FlowCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((FlowCanvas *) it.current())->write_horizontally =
+                    canvas->write_horizontally =
                         write_horizontally;
 
-                ((FlowCanvas *) it.current())->settings.set(st, 1);
-                ((FlowCanvas *) it.current())->propagate_drawing_settings();
-                ((FlowCanvas *) it.current())->modified();
+                canvas->settings.set(st, 1);
+                canvas->propagate_drawing_settings();
+                canvas->modified();
             }
         }
 

--- a/src/diagram/FlowCanvas.h
+++ b/src/diagram/FlowCanvas.h
@@ -78,7 +78,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/FragmentCanvas.cpp
+++ b/src/diagram/FragmentCanvas.cpp
@@ -208,20 +208,16 @@ void FragmentCanvas::moveBy(double dx, double dy)
 {
     DiagramCanvas::moveBy(dx, dy);
 
-    Q3PtrListIterator<FragmentSeparatorCanvas> it(separators);
-
-    for (; it.current(); ++it)
-        it.current()->update();
+    foreach (FragmentSeparatorCanvas *canvas, separators)
+        canvas->update();
 }
 
 void FragmentCanvas::set_z(double z)
 {
     setZ(z);
 
-    Q3PtrListIterator<FragmentSeparatorCanvas> it(separators);
-
-    for (; it.current(); ++it)
-        it.current()->update();
+    foreach (FragmentSeparatorCanvas *canvas, separators)
+        canvas->update();
 }
 
 void FragmentCanvas::open()
@@ -319,10 +315,8 @@ void FragmentCanvas::change_scale()
     recenter();
     Q3CanvasRectangle::setVisible(TRUE);
 
-    Q3PtrListIterator<FragmentSeparatorCanvas> it(separators);
-
-    for (; it.current(); ++it)
-        it.current()->update();
+    foreach (FragmentSeparatorCanvas *canvas, separators)
+        canvas->update();
 }
 
 void FragmentCanvas::modified()
@@ -481,7 +475,7 @@ bool FragmentCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void FragmentCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void FragmentCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -494,11 +488,9 @@ void FragmentCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((FragmentCanvas *) it.current())->itscolor = itscolor;
-                ((FragmentCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                ((FragmentCanvas *) item)->itscolor = itscolor;
+                ((FragmentCanvas *) item)->modified(); // call package_modified()
             }
         }
 
@@ -533,19 +525,15 @@ void FragmentCanvas::resize(aCorner c, int dx, int dy, QPoint & o)
 {
     DiagramCanvas::resize(c, dx, dy, o, min_width, min_height);
 
-    Q3PtrListIterator<FragmentSeparatorCanvas> it(separators);
-
-    for (; it.current(); ++it)
-        it.current()->update();
+    foreach (FragmentSeparatorCanvas *canvas, separators)
+        canvas->update();
 }
 
 void FragmentCanvas::resize(const QSize & sz, bool w, bool h)
 {
     if (DiagramCanvas::resize(sz, w, h, min_width, min_height)) {
-        Q3PtrListIterator<FragmentSeparatorCanvas> it(separators);
-
-        for (; it.current(); ++it)
-            it.current()->update();
+        foreach (FragmentSeparatorCanvas *canvas, separators)
+            canvas->update();
     }
 }
 
@@ -603,10 +591,8 @@ void FragmentCanvas::save(QTextStream & st, bool ref, QString & warning) const
 
         save_xyzwh(st, this, "xyzwh");
 
-        Q3PtrListIterator<FragmentSeparatorCanvas> it(separators);
-
-        for (; it.current(); ++it)
-            it.current()->save(st, FALSE, warning);
+        foreach (FragmentSeparatorCanvas *canvas, separators)
+            canvas->save(st, false, warning);
 
         indent(-1);
         nl_indent(st);
@@ -673,10 +659,9 @@ void FragmentCanvas::history_save(QBuffer & b) const
 
     ::save((int) separators.count(), b);
 
-    Q3PtrListIterator<FragmentSeparatorCanvas> it(separators);
 
-    for (; it.current(); ++it)
-        ::save(it.current(), b);
+    foreach (FragmentSeparatorCanvas *canvas, separators)
+        ::save(canvas, b);
 }
 
 void FragmentCanvas::history_load(QBuffer & b)
@@ -724,8 +709,8 @@ void FragmentCanvas::history_hide()
 // for plug outs
 
 void FragmentCanvas::send(ToolCom * com, Q3CanvasItemList & all,
-                          Q3PtrList<FragmentCanvas> & fragments,
-                          Q3PtrList<FragmentCanvas> & refs)
+                          QList<FragmentCanvas *> & fragments,
+                          QList<FragmentCanvas *> & refs)
 {
     Q3CanvasItemList::Iterator cit;
 
@@ -738,9 +723,7 @@ void FragmentCanvas::send(ToolCom * com, Q3CanvasItemList & all,
 
     com->write_unsigned(fragments.count());
 
-    FragmentCanvas * f;
-
-    for (f = fragments.first(); f != 0; f = fragments.next()) {
+    foreach (FragmentCanvas * f, fragments) {
         WrapperStr s = fromUnicode(f->name);
 
         com->write_string((const char *) s);
@@ -753,11 +736,11 @@ void FragmentCanvas::send(ToolCom * com, Q3CanvasItemList & all,
             com->write_unsigned(1);
         else {
             FragmentSeparatorCanvas ** v = new FragmentSeparatorCanvas *[sz];
-            unsigned index;
-            Q3PtrListIterator<FragmentSeparatorCanvas> it(f->separators);
-
-            for (index = 0; it.current(); ++it, index += 1)
-                v[index] = it.current();
+            unsigned index = 0;
+            foreach (FragmentSeparatorCanvas *canvas, f->separators) {
+                v[index] = canvas;
+                ++index;
+            }
 
             bool modified;
 

--- a/src/diagram/FragmentCanvas.h
+++ b/src/diagram/FragmentCanvas.h
@@ -47,7 +47,7 @@ protected:
     QString name;
     int min_width;
     int min_height;
-    Q3PtrList<FragmentSeparatorCanvas> separators;
+    QList<FragmentSeparatorCanvas *> separators;
     BrowserNode * refer;
     QString form;
 
@@ -86,7 +86,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 
@@ -97,8 +97,8 @@ public:
     }
 
     static void send(ToolCom * com, Q3CanvasItemList & all,
-                     Q3PtrList<FragmentCanvas> & fragments,
-                     Q3PtrList<FragmentCanvas> & refs);
+                     QList<FragmentCanvas *> & fragments,
+                     QList<FragmentCanvas *> & refs);
 
 private slots:
     void modified();

--- a/src/diagram/InfoCanvas.cpp
+++ b/src/diagram/InfoCanvas.cpp
@@ -225,7 +225,7 @@ bool InfoCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void InfoCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void InfoCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -238,11 +238,10 @@ void InfoCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((InfoCanvas *) it.current())->itscolor = itscolor;
-                ((InfoCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                InfoCanvas *canvas = (InfoCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();	// call package_modified()
             }
         }
 

--- a/src/diagram/InfoCanvas.h
+++ b/src/diagram/InfoCanvas.h
@@ -52,7 +52,7 @@ public:
 
     virtual void apply_shortcut(QString s);
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void save(QTextStream  & st, bool ref, QString & warning) const;

--- a/src/diagram/InterruptibleActivityRegionCanvas.cpp
+++ b/src/diagram/InterruptibleActivityRegionCanvas.cpp
@@ -401,7 +401,7 @@ bool InterruptibleActivityRegionCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void InterruptibleActivityRegionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void InterruptibleActivityRegionCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -414,11 +414,10 @@ void InterruptibleActivityRegionCanvas::edit_drawing_settings(Q3PtrList<DiagramI
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((InterruptibleActivityRegionCanvas *) it.current())->itscolor = itscolor;
-                ((InterruptibleActivityRegionCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                InterruptibleActivityRegionCanvas *canvas = (InterruptibleActivityRegionCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 

--- a/src/diagram/InterruptibleActivityRegionCanvas.h
+++ b/src/diagram/InterruptibleActivityRegionCanvas.h
@@ -80,7 +80,7 @@ public:
     virtual bool move_with_its_package() const;
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/NoteCanvas.cpp
+++ b/src/diagram/NoteCanvas.cpp
@@ -355,7 +355,7 @@ bool NoteCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void NoteCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void NoteCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -368,11 +368,10 @@ void NoteCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((NoteCanvas *) it.current())->itscolor = itscolor;
-                ((NoteCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                NoteCanvas *canvas = (NoteCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 

--- a/src/diagram/NoteCanvas.h
+++ b/src/diagram/NoteCanvas.h
@@ -75,7 +75,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/ObjectDiagramView.cpp
+++ b/src/diagram/ObjectDiagramView.cpp
@@ -247,7 +247,6 @@ void ObjectDiagramView::save(QTextStream & st, QString & warning,
                              bool copy) const
 {
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
     if (!copy)
         // sort is useless for a copy
@@ -257,7 +256,7 @@ void ObjectDiagramView::save(QTextStream & st, QString & warning,
 
     // save first the packages fragment, classes instances, notes, icons and text
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlPackage:
         case UmlFragment:
@@ -277,7 +276,7 @@ void ObjectDiagramView::save(QTextStream & st, QString & warning,
 
     // then save links
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         UmlCode k = di->type();
 
         if (IsaRelation(k) || (k == UmlObjectLink)) {
@@ -288,7 +287,7 @@ void ObjectDiagramView::save(QTextStream & st, QString & warning,
 
     // then save anchors
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) && (di->type() == UmlAnchor))
             di->save(st, FALSE, warning);
 

--- a/src/diagram/ObjectLinkCanvas.cpp
+++ b/src/diagram/ObjectLinkCanvas.cpp
@@ -261,7 +261,7 @@ void ObjectLinkCanvas::open()
         last = (ObjectLinkCanvas *)((ArrowPointCanvas *) last->end)->get_other(last);
 
     // compute all compatible relations in the two directions
-    Q3PtrList<RelationData> l;
+    QList<RelationData *> l;
     int nfirstdir;
 
     ((BrowserClass *)((OdClassInstCanvas *) first->begin)->get_type())

--- a/src/diagram/OdClassInstCanvas.cpp
+++ b/src/diagram/OdClassInstCanvas.cpp
@@ -232,12 +232,10 @@ void OdClassInstCanvas::modified()
         if (the_canvas()->must_draw_all_relations())
             draw_all_relations();
 
-        Q3PtrListIterator<ArrowCanvas> it(lines);
-
-        for (; it.current(); ++it)
-            if (IsaRelation(it.current()->type()))
+        foreach (ArrowCanvas *canvas, lines)
+            if (IsaRelation(canvas->type()))
                 // useless to check UmlObjectLink ie unset link
-                ((ObjectLinkCanvas *) it.current())->check();
+                ((ObjectLinkCanvas *) canvas)->check();
 
         canvas()->update();
         package_modified();
@@ -252,16 +250,11 @@ void OdClassInstCanvas::post_loaded()
 
 bool OdClassInstCanvas::has_relation(const SlotRel & slot_rel) const
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if (IsaRelation(it.current()->type()) &&
-            (((ObjectLinkCanvas *) it.current())
-             ->is(slot_rel, it.current()->get_start() == (DiagramItem *) this)))
+    foreach (ArrowCanvas *canvas, lines)
+        if (IsaRelation(canvas->type()) &&
+            (((ObjectLinkCanvas *) canvas)
+             ->is(slot_rel, canvas->get_start() == (DiagramItem *) this)))
             return TRUE;
-
-        ++it;
-    }
 
     return FALSE;
 }
@@ -271,18 +264,13 @@ bool OdClassInstCanvas::is_duplicated(ObjectLinkCanvas * lnk,
                                       OdClassInstCanvas * other) const
 {
     RelationData * rel = lnk->get_rel();
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-    ArrowCanvas * ar;
 
-    while ((ar = it.current()) != 0) {
+    foreach (ArrowCanvas *ar, lines)
         if ((ar != lnk) &&
             IsaRelation(ar->type()) &&
             (((ObjectLinkCanvas *) ar)->get_rel() == rel) &&
             (ar->get_end() == other))
             return TRUE;
-        else
-            ++it;
-    }
 
     return FALSE;
 }
@@ -706,7 +694,7 @@ bool OdClassInstCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void OdClassInstCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void OdClassInstCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(2);
@@ -724,21 +712,20 @@ void OdClassInstCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                OdClassInstCanvas *canvas = (OdClassInstCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((OdClassInstCanvas *) it.current())->write_horizontally =
+                    canvas->write_horizontally =
                         write_horizontally;
 
                 if (!st[1].name.isEmpty())
-                    ((OdClassInstCanvas *) it.current())->show_context_mode =
+                    canvas->show_context_mode =
                         show_context_mode;
 
                 if (!co[0].name.isEmpty())
-                    ((OdClassInstCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((OdClassInstCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();
             }
         }
 

--- a/src/diagram/OdClassInstCanvas.h
+++ b/src/diagram/OdClassInstCanvas.h
@@ -86,7 +86,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/PackageCanvas.cpp
+++ b/src/diagram/PackageCanvas.cpp
@@ -651,7 +651,7 @@ bool PackageCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void PackageCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void PackageCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(3);
@@ -671,22 +671,21 @@ void PackageCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                PackageCanvas *canvas = (PackageCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((PackageCanvas *) it.current())->name_in_tab = name_in_tab;
+                    canvas->name_in_tab = name_in_tab;
 
                 if (!st[1].name.isEmpty())
-                    ((PackageCanvas *) it.current())->show_context_mode = show_context_mode;
+                    canvas->show_context_mode = show_context_mode;
 
                 if (!st[2].name.isEmpty())
-                    ((PackageCanvas *) it.current())->show_stereotype_properties = show_stereotype_properties;
+                    canvas->show_stereotype_properties = show_stereotype_properties;
 
                 if (!co[0].name.isEmpty())
-                    ((PackageCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((PackageCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();
             }
         }
 

--- a/src/diagram/PackageCanvas.h
+++ b/src/diagram/PackageCanvas.h
@@ -77,7 +77,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/ParameterCanvas.cpp
+++ b/src/diagram/ParameterCanvas.cpp
@@ -511,7 +511,7 @@ bool ParameterCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ParameterCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ParameterCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -524,11 +524,10 @@ void ParameterCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((ParameterCanvas *) it.current())->itscolor = itscolor;
-                ((ParameterCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                ParameterCanvas *canvas = (ParameterCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 

--- a/src/diagram/ParameterCanvas.h
+++ b/src/diagram/ParameterCanvas.h
@@ -79,7 +79,7 @@ public:
     bool activity_selected() const;
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/ParameterSetCanvas.cpp
+++ b/src/diagram/ParameterSetCanvas.cpp
@@ -436,7 +436,7 @@ bool ParameterSetCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void ParameterSetCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void ParameterSetCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -449,11 +449,10 @@ void ParameterSetCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((ParameterSetCanvas *) it.current())->itscolor = itscolor;
-                ((ParameterSetCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                ParameterSetCanvas *canvas = (ParameterSetCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();	// call package_modified()
             }
         }
 

--- a/src/diagram/ParameterSetCanvas.h
+++ b/src/diagram/ParameterSetCanvas.h
@@ -77,7 +77,7 @@ public:
     void do_change_scale();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/PinCanvas.cpp
+++ b/src/diagram/PinCanvas.cpp
@@ -512,7 +512,7 @@ bool PinCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void PinCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void PinCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -525,11 +525,10 @@ void PinCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((PinCanvas *) it.current())->itscolor = itscolor;
-                ((PinCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                PinCanvas *canvas = (PinCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 

--- a/src/diagram/PinCanvas.h
+++ b/src/diagram/PinCanvas.h
@@ -76,7 +76,7 @@ public:
     bool action_selected() const;
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/RelationCanvas.cpp
+++ b/src/diagram/RelationCanvas.cpp
@@ -1232,12 +1232,7 @@ void RelationCanvas::show_assoc_class(CdClassCanvas * cc)
 
     for (;;) {
         // goes throw the line and check / search assoc
-        Q3PtrList<ArrowCanvas> l = rc->lines;
-        Q3PtrListIterator<ArrowCanvas> it(l);
-
-        for (; it.current(); ++it) {
-            ArrowCanvas * a = it.current();
-
+        foreach (ArrowCanvas *a, rc->lines) {
             if (a->type() == UmlAnchor) {
                 DiagramItem * s = a->get_start();
                 DiagramItem * e = a->get_end();
@@ -1286,11 +1281,7 @@ void RelationCanvas::hide_assoc_class()
 
     for (;;) {
         // goes through the line to remove existing assoc
-        Q3PtrListIterator<ArrowCanvas> it(rc->lines);
-
-        for (; it.current(); ++it) {
-            ArrowCanvas * a = it.current();
-
+        foreach (ArrowCanvas *a, rc->lines) {
             if ((a->type() == UmlAnchor) &&
                 ((a->get_start()->type() == UmlClass) ||
                  (a->get_end()->type() == UmlClass))) {

--- a/src/diagram/SdClassInstCanvas.cpp
+++ b/src/diagram/SdClassInstCanvas.cpp
@@ -586,7 +586,7 @@ bool SdClassInstCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void SdClassInstCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void SdClassInstCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(3);
@@ -606,25 +606,24 @@ void SdClassInstCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                SdClassInstCanvas *canvas = (SdClassInstCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((SdClassInstCanvas *) it.current())->drawing_mode =
+                    canvas->drawing_mode =
                         drawing_mode;
 
                 if (!st[1].name.isEmpty())
-                    ((SdClassInstCanvas *) it.current())->write_horizontally =
+                    canvas->write_horizontally =
                         write_horizontally;
 
                 if (!st[2].name.isEmpty())
-                    ((SdClassInstCanvas *) it.current())->show_context_mode =
+                    canvas->show_context_mode =
                         show_context_mode;
 
                 if (!co[0].name.isEmpty())
-                    ((SdClassInstCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((SdClassInstCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();	// call package_modified()
             }
         }
 
@@ -798,7 +797,7 @@ void SdClassInstCanvas::history_load(QBuffer & b)
 
 void SdClassInstCanvas::send(ToolCom * com, Q3CanvasItemList & all)
 {
-    Q3PtrList<SdClassInstCanvas> l;
+    QList<SdClassInstCanvas *> l;
     Q3CanvasItemList::Iterator cit;
 
     for (cit = all.begin(); cit != all.end(); ++cit) {
@@ -819,11 +818,7 @@ void SdClassInstCanvas::send(ToolCom * com, Q3CanvasItemList & all)
 
     com->write_unsigned(l.count());
 
-    Q3PtrListIterator<SdClassInstCanvas> it(l);
-
-    for (; it.current(); ++it) {
-        SdClassInstCanvas * i = it.current();
-
+    foreach (SdClassInstCanvas *i, l) {
         com->write_unsigned((unsigned) i->get_ident());
 
         if (i->browser_node->get_type() == UmlClass) {

--- a/src/diagram/SdClassInstCanvas.h
+++ b/src/diagram/SdClassInstCanvas.h
@@ -78,7 +78,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/SdContinuationCanvas.cpp
+++ b/src/diagram/SdContinuationCanvas.cpp
@@ -310,7 +310,7 @@ bool SdContinuationCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void SdContinuationCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void SdContinuationCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -323,11 +323,10 @@ void SdContinuationCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((SdContinuationCanvas *) it.current())->itscolor = itscolor;
-                ((SdContinuationCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                SdContinuationCanvas *canvas = (SdContinuationCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 

--- a/src/diagram/SdContinuationCanvas.h
+++ b/src/diagram/SdContinuationCanvas.h
@@ -71,7 +71,7 @@ public:
     virtual void change_scale();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/SdDurationCanvas.cpp
+++ b/src/diagram/SdDurationCanvas.cpp
@@ -119,10 +119,8 @@ void SdDurationCanvas::update_hpos()
 {
     move(support->sub_x(width()), 100000);
 
-    Q3PtrListIterator<SdDurationCanvas> itd(durations);
-
-    for (; itd.current(); ++itd)
-        itd.current()->update_hpos();
+    foreach (SdDurationCanvas *canvas, durations)
+        canvas->update_hpos();
 }
 
 void SdDurationCanvas::draw(QPainter & p)
@@ -202,10 +200,8 @@ void SdDurationCanvas::moveBy(double dx, double dy)
         DiagramCanvas::moveBy(dx, 0);
 
         // update messages position (even selected, this case is managed by the messages)
-        Q3PtrListIterator<SdMsgBaseCanvas> it(msgs);
-
-        for (; it.current(); ++it)
-            it.current()->update_hpos();
+        foreach (SdMsgBaseCanvas *canvas, msgs)
+            canvas->update_hpos();
     }
     else {
         double my = min_y();
@@ -217,10 +213,8 @@ void SdDurationCanvas::moveBy(double dx, double dy)
         DiagramCanvas::moveBy(0, dy);
 
         // move messages (even selected, this case is managed by the messages)
-        Q3PtrListIterator<SdMsgBaseCanvas> it(msgs);
-
-        for (; it.current(); ++it)
-            it.current()->moveBy(100000, dy);
+        foreach (SdMsgBaseCanvas *canvas, msgs)
+            canvas->moveBy(100000, dy);
     }
 
     support->update_v_to_contain(this, FALSE);
@@ -232,12 +226,10 @@ void SdDurationCanvas::prepare_for_move(bool on_resize)
     DiagramCanvas::prepare_for_move(on_resize);
 
     if (! on_resize) {
-        Q3PtrListIterator<SdDurationCanvas> itd(durations);
-
-        for (; itd.current(); ++itd) {
-            if (! itd.current()->selected()) {
-                the_canvas()->select(itd.current());
-                itd.current()->prepare_for_move(on_resize);
+        foreach (SdDurationCanvas *canvas, durations) {
+            if (! canvas->selected()) {
+                the_canvas()->select(canvas);
+                canvas->prepare_for_move(on_resize);
             }
         }
     }
@@ -304,11 +296,10 @@ void SdDurationCanvas::update_v_to_contain(SdDurationCanvas * d, bool force)
 
 void SdDurationCanvas::update_self()
 {
-    Q3PtrListIterator<SdMsgBaseCanvas> it(msgs);
     QRect r = rect();
 
-    for (; it.current(); ++it)
-        it.current()->check_vpos(r);
+    foreach (SdMsgBaseCanvas *canvas, msgs)
+        canvas->check_vpos(r);
 }
 
 QString SdDurationCanvas::may_start(UmlCode &) const
@@ -446,7 +437,7 @@ void SdDurationCanvas::add(SdMsgBaseCanvas * m)
 
 void SdDurationCanvas::remove(SdMsgBaseCanvas * m)
 {
-    msgs.removeRef(m);
+    msgs.remove(m);
 
     if (msgs.isEmpty() && durations.isEmpty())
         // now useless, remove it
@@ -469,20 +460,15 @@ void SdDurationCanvas::remove(SdDurationCanvas * d)
 
 void SdDurationCanvas::cut_internal(int py)
 {
-    Q3PtrListIterator<SdDurationCanvas> itd(durations);
-
-    for (; itd.current(); ++itd)
-        itd.current()->cut_internal(py);
+    foreach (SdDurationCanvas *canvas, durations)
+        canvas->cut_internal(py);
 
     QRect r = rect();
     resize(width(), py - r.top());
     SdDurationCanvas * newone = 0;
 
-    Q3PtrList<SdMsgBaseCanvas> ms(msgs);
-    Q3PtrListIterator<SdMsgBaseCanvas> it(ms);
-
-    for (; it.current(); ++it) {
-        if (it.current()->rect().center().y() > py) {
+    foreach (SdMsgBaseCanvas *canvas, msgs) {
+        if (canvas->rect().center().y() > py) {
             // on the new duration
             if (newone == 0) {
                 // width and height to 0 on creation to not have
@@ -494,17 +480,14 @@ void SdDurationCanvas::cut_internal(int py)
                 newone->show();
             }
 
-            remove(it.current());
-            newone->add(it.current());
-            it.current()->change_duration(this, newone);
+            remove(canvas);
+            newone->add(canvas);
+            canvas->change_duration(this, newone);
         }
     }
 
-    Q3PtrList<SdDurationCanvas> durs(durations);
-    Q3PtrListIterator<SdDurationCanvas> itdur(durs);
-
-    for (itdur.toFirst() ; itdur.current(); ++itdur) {
-        if (itdur.current()->rect().center().y() > py) {
+    foreach (SdDurationCanvas *canvas, durations) {
+        if (canvas->rect().center().y() > py) {
             // on the new duration
             if (newone == 0) {
                 // width and height to 0 on creation to not have
@@ -516,12 +499,12 @@ void SdDurationCanvas::cut_internal(int py)
                 newone->show();
             }
 
-            remove(itdur.current());
-            newone->add(itdur.current());
-            itdur.current()->support =  newone;
+            remove(canvas);
+            newone->add(canvas);
+            canvas->support =  newone;
         }
 
-        itdur.current()->update_v_to_contain(itdur.current(), TRUE);
+        canvas->update_v_to_contain(canvas, TRUE);
     }
 }
 
@@ -531,16 +514,15 @@ void SdDurationCanvas::cut(const QPoint & p)
     package_modified();
 }
 
-void SdDurationCanvas::merge(Q3PtrList<SdDurationCanvas> & l)
+void SdDurationCanvas::merge(QList<SdDurationCanvas *> & l)
 {
-    l.removeRef(this);
+    l.remove(this);
 
     QRect r = rect();
     int vmin = r.top();
     int vmax = r.bottom();
-    SdDurationCanvas * d;
 
-    for (d = l.first(); d != 0; d = l.next()) {
+    foreach (SdDurationCanvas *d, l) {
         QRect dr = d->rect();
 
         if (dr.top() < vmin)
@@ -561,23 +543,17 @@ void SdDurationCanvas::merge(Q3PtrList<SdDurationCanvas> & l)
 
 void SdDurationCanvas::collapse(SdDurationCanvas * d)
 {
-    Q3PtrList<SdMsgBaseCanvas> & ms = d->msgs;
-
-    while (! ms.isEmpty()) {
-        SdMsgBaseCanvas * m = ms.take(0);
-
-        msgs.append(m);
+    foreach (SdMsgBaseCanvas *m, d->msgs) {
+        msgs << m;
         m->change_duration(d, this);
     }
+    d->msgs.clear();
 
-    Q3PtrList<SdDurationCanvas> & durs = d->durations;
-
-    while (! durs.isEmpty()) {
-        SdDurationCanvas * dur = durs.take(0);
-
-        durations.append(dur);
+    foreach (SdDurationCanvas *dur, d->durations) {
+        durations << dur;
         dur->support = this;
     }
+    d->durations.clear();
 
     d->delete_it();
 }
@@ -596,7 +572,7 @@ void SdDurationCanvas::go_up(SdMsgBaseCanvas * m, bool isdest)
     m->change_duration(this, d);
     d->update_hpos(); // update sub duration and msg hpos
     d->update_self();
-    msgs.removeRef(m);
+    msgs.remove(m);
     m->upper();
 }
 
@@ -615,7 +591,7 @@ void SdDurationCanvas::go_down(SdMsgBaseCanvas * m)
 void SdDurationCanvas::toFlat()
 {
     while (! durations.isEmpty()) {
-        SdDurationCanvas * d = durations.getFirst();
+        SdDurationCanvas * d = durations.first();
 
         d->toFlat();
         collapse(d);
@@ -633,7 +609,7 @@ void SdDurationCanvas::toOverlapping()
     unsigned index = 0;
 
     while (! msgs.isEmpty())
-        v[index++] = msgs.take(0);
+        v[index++] = msgs.takeFirst();
 
     unsigned sup = sz;
 
@@ -719,17 +695,13 @@ void SdDurationCanvas::toOverlapping(SdMsgBaseCanvas ** v,
 
 void SdDurationCanvas::postToOverlapping()
 {
-    Q3PtrListIterator<SdDurationCanvas> itd(durations);
+    foreach (SdDurationCanvas *canvas, durations)
+        canvas->postToOverlapping();
 
-    for (; itd.current(); ++itd)
-        itd.current()->postToOverlapping();
-
-    Q3PtrListIterator<SdMsgBaseCanvas> it(msgs);
-
-    for (; it.current(); ++it) {
-        it.current()->upper();
-        it.current()->update_hpos();
-        ((DiagramItem *) it.current())->update();	// not QCanvasItem::update
+    foreach (SdMsgBaseCanvas *canvas, msgs) {
+        canvas->upper();
+        canvas->update_hpos();
+        canvas->DiagramItem::update();	// not QCanvasItem::update
     }
 }
 
@@ -751,7 +723,7 @@ void SdDurationCanvas::menu(const QPoint & p)
 {
     Q3PopupMenu m(0);
     Q3CanvasItemList items = collisions(TRUE);
-    Q3PtrList<SdDurationCanvas> l;
+    QList<SdDurationCanvas *> l;
     Q3CanvasItemList::ConstIterator it;
     Q3CanvasItemList::ConstIterator end = items.end();
 
@@ -899,7 +871,7 @@ bool SdDurationCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void SdDurationCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void SdDurationCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -912,11 +884,10 @@ void SdDurationCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((SdDurationCanvas *) it.current())->itscolor = itscolor;
-                ((SdDurationCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                SdDurationCanvas *canvas = (SdDurationCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 
@@ -992,11 +963,9 @@ void SdDurationCanvas::select_associated()
     if (! selected())
         the_canvas()->select(this);
 
-    Q3PtrListIterator<SdMsgBaseCanvas> it(msgs);
-
-    for (; it.current(); ++it)
-        if (! it.current()->selected())
-            it.current()->select_associated();
+    foreach (SdMsgBaseCanvas *canvas, msgs)
+        if (! canvas->selected())
+            canvas->select_associated();
 }
 
 bool SdDurationCanvas::copyable() const
@@ -1004,10 +973,8 @@ bool SdDurationCanvas::copyable() const
     if (! selected())
         return FALSE;
 
-    Q3PtrListIterator<SdMsgBaseCanvas> it(msgs);
-
-    for (; it.current(); ++it)
-        if (it.current()->copyable())
+    foreach (SdMsgBaseCanvas *canvas, msgs)
+        if (canvas->copyable())
             return TRUE;
 
     return FALSE;
@@ -1045,29 +1012,21 @@ double SdDurationCanvas::getZ() const
     return z();
 }
 
-void SdDurationCanvas::propag_visible(Q3PtrList<SdDurationCanvas> & l, bool y)
+void SdDurationCanvas::propag_visible(QList<SdDurationCanvas *> & l, bool y)
 {
-    Q3PtrListIterator<SdDurationCanvas> itd(l);
-    SdDurationCanvas * d;
-
-    for (; (d = itd.current()) != 0; ++itd) {
+    foreach (SdDurationCanvas *d, l) {
         d->Q3CanvasItem::setVisible(y);
 
-        Q3PtrListIterator<SdMsgBaseCanvas> itm(d->msgs);
-
-        for (; itm.current(); ++itm)
-            itm.current()->Q3CanvasItem::setVisible(y);
+        foreach (SdMsgBaseCanvas *msg, d->msgs)
+            msg->Q3CanvasItem::setVisible(y);
 
         propag_visible(d->durations, y);
     }
 }
 
-void SdDurationCanvas::propag_dz(Q3PtrList<SdDurationCanvas> & l, double dz)
+void SdDurationCanvas::propag_dz(QList<SdDurationCanvas *> & l, double dz)
 {
-    Q3PtrListIterator<SdDurationCanvas> it(l);
-    SdDurationCanvas * d;
-
-    for (; (d = it.current()) != 0; ++it) {
+    foreach (SdDurationCanvas *d, l) {
         d->Q3CanvasItem::setZ(d->z() + dz);
         propag_dz(d->durations, dz);
     }
@@ -1097,10 +1056,8 @@ void SdDurationCanvas::save_internal(QTextStream & st) const
     nl_indent(st);
     save_xyzwh(st, this, "xyzwh");
 
-    Q3PtrListIterator<SdDurationCanvas> itd(durations);
-
-    for (; itd.current(); ++itd)
-        itd.current()->save_sub(st);
+    foreach (SdDurationCanvas *canvas, durations)
+        canvas->save_sub(st);
 
     indent(-1);
     nl_indent(st);
@@ -1209,19 +1166,15 @@ void SdDurationCanvas::history_save(QBuffer & b) const
     ::save(height(), b);
     ::save_ptr(support, b);
 
-    Q3PtrListIterator<SdMsgBaseCanvas> it(msgs);
-
     ::save((int) msgs.count(), b);
 
-    for (; it.current(); ++it)
-        ::save(it.current(), b);
-
-    Q3PtrListIterator<SdDurationCanvas> itd(durations);
+    foreach (SdMsgBaseCanvas *canvas, msgs)
+        ::save(canvas, b);
 
     ::save((int) durations.count(), b);
 
-    for (; itd.current(); ++itd)
-        ::save(itd.current(), b);
+    foreach (SdDurationCanvas *canvas, durations)
+        ::save(canvas, b);
 }
 
 void SdDurationCanvas::history_load(QBuffer & b)
@@ -1260,16 +1213,15 @@ void SdDurationCanvas::history_load(QBuffer & b)
 unsigned SdDurationCanvas::count_msg(int api_format) const
 {
     unsigned count = 0;
-    Q3PtrListIterator<SdMsgBaseCanvas> itm(msgs);
     double maxy = 0;
     bool isreturn = FALSE;
 
-    for (; itm.current(); ++itm) {
-        switch (itm.current()->type()) {
+    foreach (SdMsgBaseCanvas *canvas, msgs) {
+        switch (canvas->type()) {
         case UmlSyncMsg:
         case UmlAsyncMsg:
         case UmlReturnMsg:
-            if (itm.current()->get_dest() == (const SdMsgSupport *) this)
+            if (canvas->get_dest() == (const SdMsgSupport *) this)
                 break;
 
             // no break
@@ -1278,10 +1230,10 @@ unsigned SdDurationCanvas::count_msg(int api_format) const
             count += 1;
         }
 
-        if (itm.current()->y() > maxy) {
-            maxy = itm.current()->y();
+        if (canvas->y() > maxy) {
+            maxy = canvas->y();
 
-            switch (itm.current()->type()) {
+            switch (canvas->type()) {
             case UmlReturnMsg:
             case UmlSelfReturnMsg:
                 isreturn = TRUE;
@@ -1296,38 +1248,35 @@ unsigned SdDurationCanvas::count_msg(int api_format) const
     if (!isreturn)
         count += 1;
 
-    Q3PtrListIterator<SdDurationCanvas> itd(durations);
-
-    for (; itd.current(); ++itd)
-        count += itd.current()->count_msg(api_format);
+    foreach (SdDurationCanvas *canvas, durations)
+        count += canvas->count_msg(api_format);
 
     return count;
 }
 
 void SdDurationCanvas::send(ToolCom * com, int id) const
 {
-    Q3PtrListIterator<SdMsgBaseCanvas> itm(msgs);
     double maxy = 0;
     bool isreturn = FALSE;
 
-    for (; itm.current(); ++itm) {
-        switch (itm.current()->type()) {
+    foreach (SdMsgBaseCanvas *canvas, msgs) {
+        switch (canvas->type()) {
         case UmlSyncMsg:
         case UmlAsyncMsg:
         case UmlReturnMsg:
-            if (itm.current()->get_dest() == (const SdMsgSupport *) this)
+            if (canvas->get_dest() == (const SdMsgSupport *) this)
                 break;
 
             // no break
         default:
             // msg start from duration, except for found msg
-            itm.current()->send(com, id);
+            canvas->send(com, id);
         }
 
-        if (itm.current()->y() > maxy) {
-            maxy = itm.current()->y();
+        if (canvas->y() > maxy) {
+            maxy = canvas->y();
 
-            switch (itm.current()->type()) {
+            switch (canvas->type()) {
             case UmlReturnMsg:
             case UmlSelfReturnMsg:
                 isreturn = TRUE;
@@ -1344,8 +1293,6 @@ void SdDurationCanvas::send(ToolCom * com, int id) const
                               (unsigned) y() + height(),
                               anImplicitReturn, "", "", "");
 
-    Q3PtrListIterator<SdDurationCanvas> itd(durations);
-
-    for (; itd.current(); ++itd)
-        itd.current()->send(com, id);
+    foreach (SdDurationCanvas *canvas, durations)
+        canvas->send(com, id);
 }

--- a/src/diagram/SdDurationCanvas.h
+++ b/src/diagram/SdDurationCanvas.h
@@ -46,8 +46,8 @@ class SdDurationCanvas : public QObject, public SdMsgSupport, public SdDurationS
 
 protected:
     SdDurationSupport * support;
-    Q3PtrList<SdDurationCanvas> durations;
-    Q3PtrList<SdMsgBaseCanvas> msgs;
+    QList<SdDurationCanvas *> durations;
+    QList<SdMsgBaseCanvas *> msgs;
     UmlColor itscolor;
     bool coregion;
 
@@ -59,7 +59,7 @@ protected:
     void cut_internal(int py);
     void update_self();
     void cut(const QPoint & p);
-    void merge(Q3PtrList<SdDurationCanvas> &);
+    void merge(QList<SdDurationCanvas *> &);
     void collapse(SdDurationCanvas *);
     void toOverlapping(SdMsgBaseCanvas **, SdDurationCanvas * orig,
                        unsigned & index, unsigned sz);
@@ -119,7 +119,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void apply_shortcut(QString s);
@@ -132,8 +132,8 @@ public:
     unsigned count_msg(int api_format) const;
     void send(ToolCom * com, int id) const;
 
-    static void propag_visible(Q3PtrList<SdDurationCanvas> &, bool y);
-    static void propag_dz(Q3PtrList<SdDurationCanvas> &, double dz);
+    static void propag_visible(QList<SdDurationCanvas *> &, bool y);
+    static void propag_dz(QList<SdDurationCanvas *> &, double dz);
 
 private slots:
     void modified();

--- a/src/diagram/SdLifeLineCanvas.h
+++ b/src/diagram/SdLifeLineCanvas.h
@@ -44,7 +44,7 @@ class ToolCom;
 class SdLifeLineCanvas : public DiagramCanvas, public SdDurationSupport
 {
 protected:
-    Q3PtrList<SdDurationCanvas> durations;
+    QList<SdDurationCanvas *> durations;
     SdObjCanvas * obj;
     int end; // 0 if masked by user, LIFE_LINE_HEIGHT if not mortal
 
@@ -103,8 +103,8 @@ public:
     virtual void history_load(QBuffer &);
 
     static void send(ToolCom * com, const Q3CanvasItemList & l,
-                     Q3PtrList<FragmentCanvas> & fragments,
-                     Q3PtrList<FragmentCanvas> & refs);
+                     QList<FragmentCanvas *> & fragments,
+                     QList<FragmentCanvas *> & refs);
 };
 
 #endif

--- a/src/diagram/SdMsgCanvas.cpp
+++ b/src/diagram/SdMsgCanvas.cpp
@@ -430,7 +430,7 @@ bool SdMsgCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void SdMsgCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void SdMsgCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(3);
@@ -447,22 +447,21 @@ void SdMsgCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                SdMsgCanvas *canvas = (SdMsgCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((SdMsgCanvas *) it.current())->drawing_language =
+                    canvas->drawing_language =
                         drawing_language;
 
                 if (!st[1].name.isEmpty())
-                    ((SdMsgCanvas *) it.current())->show_full_oper =
+                    canvas->show_full_oper =
                         show_full_oper;
 
                 if (!st[2].name.isEmpty())
-                    ((SdMsgCanvas *) it.current())->show_context_mode =
+                    canvas->show_context_mode =
                         show_context_mode;
 
-                ((SdMsgCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();
             }
         }
 

--- a/src/diagram/SdMsgCanvas.h
+++ b/src/diagram/SdMsgCanvas.h
@@ -64,7 +64,7 @@ public:
     virtual bool copyable() const;
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void apply_shortcut(QString s);

--- a/src/diagram/SdSelfMsgCanvas.cpp
+++ b/src/diagram/SdSelfMsgCanvas.cpp
@@ -411,7 +411,7 @@ bool SdSelfMsgCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void SdSelfMsgCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void SdSelfMsgCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(3);
@@ -428,22 +428,21 @@ void SdSelfMsgCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                SdSelfMsgCanvas *canvas = (SdSelfMsgCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((SdSelfMsgCanvas *) it.current())->drawing_language =
+                    canvas->drawing_language =
                         drawing_language;
 
                 if (!st[1].name.isEmpty())
-                    ((SdSelfMsgCanvas *) it.current())->show_full_oper =
+                    canvas->show_full_oper =
                         show_full_oper;
 
                 if (!st[2].name.isEmpty())
-                    ((SdSelfMsgCanvas *) it.current())->show_context_mode =
+                    canvas->show_context_mode =
                         show_context_mode;
 
-                ((SdSelfMsgCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();
             }
         }
 

--- a/src/diagram/SdSelfMsgCanvas.h
+++ b/src/diagram/SdSelfMsgCanvas.h
@@ -53,7 +53,7 @@ public:
     virtual void select_associated();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void apply_shortcut(QString s);

--- a/src/diagram/SeqDiagramView.cpp
+++ b/src/diagram/SeqDiagramView.cpp
@@ -382,7 +382,6 @@ void SeqDiagramView::save(QTextStream & st, QString & warning,
                           bool copy) const
 {
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
     if (!copy)
         // sort is useless for a copy
@@ -392,7 +391,7 @@ void SeqDiagramView::save(QTextStream & st, QString & warning,
 
     // save first the fragments, continuation, actors, classes instances, notes, icons and text
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlFragment:
         case UmlContinuation:
@@ -413,21 +412,21 @@ void SeqDiagramView::save(QTextStream & st, QString & warning,
 
     // then save durations
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) &&
             (di->type() == UmlActivityDuration))
             di->save(st, FALSE, warning);
 
     // then save lost/found start/end
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) &&
             (di->type() == UmlLostFoundMsgSupport))
             di->save(st, FALSE, warning);
 
     // then save messages
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlSyncMsg:
         case UmlAsyncMsg:
@@ -449,7 +448,7 @@ void SeqDiagramView::save(QTextStream & st, QString & warning,
 
     // then save anchors
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) && (di->type() == UmlAnchor))
             di->save(st, FALSE, warning);
 
@@ -510,8 +509,8 @@ void SeqDiagramView::read(char * st, char * k)
 void SeqDiagramView::send(ToolCom * com)
 {
     Q3CanvasItemList l = canvas()->allItems();
-    Q3PtrList<FragmentCanvas> fragments;
-    Q3PtrList<FragmentCanvas> refs;
+    QList<FragmentCanvas *> fragments;
+    QList<FragmentCanvas *> refs;
 
     FragmentCanvas::send(com, l, fragments, refs);
     SdClassInstCanvas::send(com, l);

--- a/src/diagram/StateActionCanvas.cpp
+++ b/src/diagram/StateActionCanvas.cpp
@@ -655,7 +655,7 @@ bool StateActionCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void StateActionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void StateActionCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(2);
@@ -673,19 +673,18 @@ void StateActionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l)  {
+                StateActionCanvas *canvas = (StateActionCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((StateActionCanvas *) it.current())->language = language;
+                    canvas->language = language;
 
                 if (!st[1].name.isEmpty())
-                    ((StateActionCanvas *) it.current())->show_stereotype_properties = show_stereotype_properties;
+                    canvas->show_stereotype_properties = show_stereotype_properties;
 
                 if (!co[0].name.isEmpty())
-                    ((StateActionCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((StateActionCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();	// call package_modified()
             }
         }
 

--- a/src/diagram/StateActionCanvas.h
+++ b/src/diagram/StateActionCanvas.h
@@ -85,7 +85,7 @@ public:
     virtual void resize(const QSize & sz, bool w, bool h);
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/StateCanvas.cpp
+++ b/src/diagram/StateCanvas.cpp
@@ -1436,7 +1436,7 @@ bool StateCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void StateCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void StateCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(3);
@@ -1457,25 +1457,24 @@ void StateCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                StateCanvas *canvas = (StateCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((StateCanvas *) it.current())->settings.show_activities =
+                    canvas->settings.show_activities =
                         show_activities;
 
                 if (!st[1].name.isEmpty())
-                    ((StateCanvas *) it.current())->settings.region_horizontally =
+                    canvas->settings.region_horizontally =
                         region_horizontally;
 
                 if (!st[2].name.isEmpty())
-                    ((StateCanvas *) it.current())->settings.drawing_language =
+                    canvas->settings.drawing_language =
                         language;
 
                 if (!co[0].name.isEmpty())
-                    ((StateCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((StateCanvas *) it.current())->modified();	// call package_modified()
+                canvas->modified();
             }
         }
 

--- a/src/diagram/StateCanvas.h
+++ b/src/diagram/StateCanvas.h
@@ -100,7 +100,7 @@ public:
 
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/StateDiagramView.cpp
+++ b/src/diagram/StateDiagramView.cpp
@@ -407,7 +407,6 @@ void StateDiagramView::save(QTextStream & st, QString & warning,
                             bool copy) const
 {
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
     if (!copy)
         // sort is useless for a copy
@@ -417,7 +416,7 @@ void StateDiagramView::save(QTextStream & st, QString & warning,
 
     // save first states pseudostates actions packages fragments notes and icons
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlState:
         case UmlStateAction:
@@ -449,7 +448,7 @@ void StateDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves relations
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         if (di->type() == UmlTransition) {
             if (!copy || di->copyable())
                 di->save(st, FALSE, warning);
@@ -458,7 +457,7 @@ void StateDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves anchors
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) && (di->type() == UmlAnchor))
             di->save(st, FALSE, warning);
 

--- a/src/diagram/StereotypePropertiesCanvas.cpp
+++ b/src/diagram/StereotypePropertiesCanvas.cpp
@@ -227,7 +227,7 @@ bool StereotypePropertiesCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void StereotypePropertiesCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void StereotypePropertiesCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -240,11 +240,10 @@ void StereotypePropertiesCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & 
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((StereotypePropertiesCanvas *) it.current())->itscolor = itscolor;
-                ((StereotypePropertiesCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                StereotypePropertiesCanvas *canvas = (StereotypePropertiesCanvas *)item;
+                canvas->itscolor = itscolor;
+                canvas->modified();
             }
         }
 

--- a/src/diagram/StereotypePropertiesCanvas.h
+++ b/src/diagram/StereotypePropertiesCanvas.h
@@ -59,7 +59,7 @@ public:
 
     virtual void apply_shortcut(QString s);
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void save(QTextStream  & st, bool ref, QString & warning) const;

--- a/src/diagram/SubjectCanvas.cpp
+++ b/src/diagram/SubjectCanvas.cpp
@@ -318,7 +318,7 @@ bool SubjectCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void SubjectCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void SubjectCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         ColorSpecVector co(1);
@@ -331,11 +331,9 @@ void SubjectCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if ((dialog.exec() == QDialog::Accepted) && !co[0].name.isEmpty()) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
-                ((SubjectCanvas *) it.current())->itscolor = itscolor;
-                ((SubjectCanvas *) it.current())->modified();	// call package_modified()
+            foreach (DiagramItem *item, l) {
+                ((SubjectCanvas *) item)->itscolor = itscolor;
+                ((SubjectCanvas *) item)->modified();	// call package_modified()
             }
         }
 
@@ -486,7 +484,7 @@ void SubjectCanvas::history_hide()
 
 void SubjectCanvas::send(ToolCom * com, Q3CanvasItemList & all)
 {
-    Q3PtrList<SubjectCanvas> subjects;
+    QList<SubjectCanvas *> subjects;
     Q3CanvasItemList::Iterator cit;
 
     for (cit = all.begin(); cit != all.end(); ++cit) {
@@ -500,11 +498,8 @@ void SubjectCanvas::send(ToolCom * com, Q3CanvasItemList & all)
 
     com->write_unsigned(subjects.count());
 
-    SubjectCanvas * sc;
-
-    for (sc = subjects.first(); sc != 0; sc = subjects.next()) {
+    foreach (SubjectCanvas *sc, subjects) {
         WrapperStr s = fromUnicode(sc->name);
-
         com->write_string((const char *) s);
         com->write(sc->rect());
     }

--- a/src/diagram/SubjectCanvas.h
+++ b/src/diagram/SubjectCanvas.h
@@ -72,7 +72,7 @@ public:
     virtual void change_scale();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/TransitionCanvas.cpp
+++ b/src/diagram/TransitionCanvas.cpp
@@ -403,7 +403,7 @@ bool TransitionCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void TransitionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void TransitionCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st(3);
@@ -421,23 +421,22 @@ void TransitionCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
-
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                TransitionCanvas *canvas = (TransitionCanvas *)item;
                 if (!st[0].name.isEmpty())
-                    ((TransitionCanvas *) it.current())->drawing_language =
+                    canvas->drawing_language =
                         drawing_language;
 
                 if (!st[1].name.isEmpty())
-                    ((TransitionCanvas *) it.current())->write_horizontally =
+                    canvas->write_horizontally =
                         write_horizontally;
 
                 if (!st[2].name.isEmpty())
-                    ((TransitionCanvas *) it.current())->show_definition =
+                    canvas->show_definition =
                         show_definition;
 
-                ((TransitionCanvas *) it.current())->propagate_drawing_settings();
-                ((TransitionCanvas *) it.current())->modified();	// call package_modified()
+                canvas->propagate_drawing_settings();
+                canvas->modified();	// call package_modified()
             }
         }
 

--- a/src/diagram/TransitionCanvas.h
+++ b/src/diagram/TransitionCanvas.h
@@ -73,7 +73,7 @@ public:
     virtual void history_hide();
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
 
     virtual void apply_shortcut(QString s);

--- a/src/diagram/UcClassCanvas.cpp
+++ b/src/diagram/UcClassCanvas.cpp
@@ -757,7 +757,7 @@ bool UcClassCanvas::has_drawing_settings() const
     return TRUE;
 }
 
-void UcClassCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
+void UcClassCanvas::edit_drawing_settings(QList<DiagramItem *> & l)
 {
     for (;;) {
         StateSpecVector st;
@@ -774,15 +774,15 @@ void UcClassCanvas::edit_drawing_settings(Q3PtrList<DiagramItem> & l)
         dialog.raise();
 
         if (dialog.exec() == QDialog::Accepted) {
-            Q3PtrListIterator<DiagramItem> it(l);
 
-            for (; it.current(); ++it) {
+            foreach (DiagramItem *item, l) {
+                UcClassCanvas *canvas = (UcClassCanvas *)item;
                 if (!co[0].name.isEmpty())
-                    ((UcClassCanvas *) it.current())->itscolor = itscolor;
+                    canvas->itscolor = itscolor;
 
-                ((UcClassCanvas *) it.current())->settings.set(st, 0);
-                ((UcClassCanvas *) it.current())->modified();
-                ((UcClassCanvas *) it.current())->package_modified();
+                canvas->settings.set(st, 0);
+                canvas->modified();
+                canvas->package_modified();
             }
         }
 
@@ -840,14 +840,10 @@ QString UcClassCanvas::may_connect(UmlCode & l, const DiagramItem * dest) const
 
 bool UcClassCanvas::has_relation(BasicData * def) const
 {
-    Q3PtrListIterator<ArrowCanvas> it(lines);
-
-    while (it.current()) {
-        if (IsaRelation(it.current()->type()) &&
-            (((RelationCanvas *) it.current())->get_data() == def))
+    foreach (ArrowCanvas *line, lines) {
+        if (IsaRelation(line->type()) &&
+            (((RelationCanvas *) line)->get_data() == def))
             return TRUE;
-
-        ++it;
     }
 
     return FALSE;

--- a/src/diagram/UcClassCanvas.h
+++ b/src/diagram/UcClassCanvas.h
@@ -80,7 +80,7 @@ public:
     virtual void set_z(double z);	// only called by upper() & lower()
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
     virtual bool get_show_stereotype_properties() const;

--- a/src/diagram/UcUseCaseCanvas.h
+++ b/src/diagram/UcUseCaseCanvas.h
@@ -71,7 +71,7 @@ public:
     virtual void resize(const QSize & sz, bool w, bool h);
 
     virtual bool has_drawing_settings() const;
-    virtual void edit_drawing_settings(Q3PtrList<DiagramItem> &);
+    virtual void edit_drawing_settings(QList<DiagramItem *> &);
     virtual void clone_drawing_settings(const DiagramItem *src);
     void edit_drawing_settings();
 

--- a/src/diagram/UmlCanvas.cpp
+++ b/src/diagram/UmlCanvas.cpp
@@ -37,7 +37,7 @@
 #include "ArrowPointCanvas.h"
 #include "BrowserDiagram.h"
 
-static Q3PtrList<UmlCanvas> All;
+static QList<UmlCanvas *> All;
 
 static const struct {
     int w;
@@ -94,7 +94,7 @@ UmlCanvas::UmlCanvas(CanvasFormat f, BrowserDiagram * br_diag)
 
 UmlCanvas::~UmlCanvas()
 {
-    All.removeRef(this);
+    All.remove(this);
 }
 
 void UmlCanvas::set_view(DiagramView * v)
@@ -302,9 +302,7 @@ void UmlCanvas::show_limits(bool y)
 
 void UmlCanvas::update_global_settings()
 {
-    UmlCanvas * c;
-
-    for (c = All.first(); c != 0; c = All.next()) {
+    foreach (UmlCanvas *c, All) {
         c->br_diagram->update_drawing_settings();
         c->show_shadow = c->br_diagram->get_shadow();
         c->draw_all_relations = c->br_diagram->get_draw_all_relations();

--- a/src/diagram/UseCaseDiagramView.cpp
+++ b/src/diagram/UseCaseDiagramView.cpp
@@ -72,11 +72,8 @@ UseCaseDiagramView::UseCaseDiagramView(QWidget * parent, UmlCanvas * canvas, int
 // have marked elements not yet drawn ?
 static bool marked_not_yet_drawn(Q3PtrDict<DiagramItem> & drawn)
 {
-    const Q3PtrList<BrowserNode> & l = BrowserNode::marked_nodes();
-    Q3PtrListIterator<BrowserNode> it(l);
-    BrowserNode * bn;
-
-    for (; (bn = it.current()) != 0; ++it) {
+    const QList<BrowserNode *> & l = BrowserNode::marked_nodes();
+    foreach (BrowserNode *bn, l) {
         UmlCode k = bn->get_type();
 
         switch (k) {
@@ -99,9 +96,7 @@ static bool marked_not_yet_drawn(Q3PtrDict<DiagramItem> & drawn)
 static void get_drawn(DiagramItemList & items,
                       Q3PtrDict<DiagramItem> & drawn)
 {
-    DiagramItem * di;
-
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         UmlCode k = di->type();
 
         switch (k) {
@@ -170,11 +165,9 @@ void UseCaseDiagramView::add_marked_elements(const QPoint & p,
     int x = p.x();
     int y = p.y();
     int future_y = y;
-    const Q3PtrList<BrowserNode> & l = BrowserNode::marked_nodes();
-    Q3PtrListIterator<BrowserNode> it(l);
-    BrowserNode * bn;
+    const QList<BrowserNode *> & l = BrowserNode::marked_nodes();
 
-    for (; (bn = it.current()) != 0; ++it) {
+    foreach (BrowserNode *bn, l) {
         if (drawn[bn->get_data()] == 0) {
             DiagramCanvas * dc;
 
@@ -221,7 +214,7 @@ void UseCaseDiagramView::add_marked_elements(const QPoint & p,
     UmlCanvas * cnv = (UmlCanvas *) canvas();
 
     if (! cnv->must_draw_all_relations()) {
-        for (it.toFirst(); (bn = it.current()) != 0; ++it) {
+        foreach (BrowserNode *bn, l) {
             if (drawn[bn->get_data()] == 0) {
                 UmlCode k = bn->get_type();
 
@@ -264,10 +257,8 @@ void UseCaseDiagramView::add_related_elements(DiagramItem  * di, QString what,
         int x = re.x();
         int y = re.bottom() + Diagram_Margin;
         int future_y = y;
-        Q3PtrListIterator<BrowserNode> it(l);
-        BrowserNode * bn;
 
-        for (; (bn = it.current()) != 0; ++it) {
+        foreach (BrowserNode *bn, l) {
             if (drawn[bn->get_data()] == 0) {
                 DiagramCanvas * dc;
 
@@ -500,7 +491,6 @@ void UseCaseDiagramView::save(QTextStream & st, QString & warning,
                               bool copy) const
 {
     DiagramItemList items(canvas()->allItems());
-    DiagramItem * di;
 
     if (!copy)
         // sort is useless for a copy
@@ -510,7 +500,7 @@ void UseCaseDiagramView::save(QTextStream & st, QString & warning,
 
     // save first class use_cases packages fragment subject notes and icons
 
-    for (di = items.first(); di != 0; di = items.next()) {
+    foreach (DiagramItem *di, items) {
         switch (di->type()) {
         case UmlClass:
         case UmlUseCase:
@@ -532,14 +522,14 @@ void UseCaseDiagramView::save(QTextStream & st, QString & warning,
 
     // then saves relations
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) &&
             (IsaRelation(di->type()) || IsaSimpleRelation(di->type())))
             di->save(st, FALSE, warning);
 
     // then saves anchors
 
-    for (di = items.first(); di != 0; di = items.next())
+    foreach (DiagramItem *di, items)
         if ((!copy || di->copyable()) && (di->type() == UmlAnchor))
             di->save(st, FALSE, warning);
 
@@ -591,8 +581,8 @@ void UseCaseDiagramView::read(char * st, char * k)
 void UseCaseDiagramView::send(ToolCom * com)
 {
     Q3CanvasItemList l = canvas()->allItems();
-    Q3PtrList<FragmentCanvas> fragments;
-    Q3PtrList<FragmentCanvas> refs;
+    QList<FragmentCanvas *> fragments;
+    QList<FragmentCanvas *> refs;
 
     FragmentCanvas::send(com, l, fragments, refs);
     SubjectCanvas::send(com, l);

--- a/src/dialog/ActivityActionDialog.cpp
+++ b/src/dialog/ActivityActionDialog.cpp
@@ -260,8 +260,9 @@ ActivityActionDialog::~ActivityActionDialog()
     act->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }
@@ -606,7 +607,7 @@ void AnyActionDialog::get_cond(QString & ocl_pre, QString & ocl_post,
 // opaque
 
 void OpaqueDialog::init(Q3TabDialog * t, ActivityActionData * act,
-                        OpaqueAction * d, Q3PtrList<BodyDialog> & e, bool visit)
+                        OpaqueAction * d, QList<BodyDialog *> & e, bool visit)
 {
     edits = &e;
     td = t;
@@ -832,7 +833,7 @@ bool AcceptEventDialog::update(AcceptEventAction * a)
 
 void ValueSpecificationDialog::init(Q3TabDialog * t, ActivityActionData * act,
                                     ValueSpecificationAction * d,
-                                    Q3PtrList<BodyDialog> & e, bool visit)
+                                    QList<BodyDialog *> & e, bool visit)
 {
     edits = &e;
     td = t;
@@ -1487,11 +1488,11 @@ void WithBehaviorDialog::init(BrowserNode * beh)
         behavior_co->insertItem("");
         behavior_co->setAutoCompletion(completion());
 
-        Q3PtrListIterator<BrowserNode> iter_node(*nodes);
         QStringList::Iterator iter_str = node_names->begin();
-
-        for (; iter_node.current(); ++iter_node, ++iter_str)
-            behavior_co->insertItem(*(iter_node.current()->pixmap(0)), *iter_str);
+        foreach (BrowserNode *node, *nodes) {
+            behavior_co->insertItem(*(node->pixmap(0)), *iter_str);
+            ++iter_str;
+        }
 
         if (beh != 0)
             behavior_co->setCurrentItem(node_names->findIndex(beh->full_name(TRUE)) + 1);

--- a/src/dialog/ActivityActionDialog.h
+++ b/src/dialog/ActivityActionDialog.h
@@ -85,14 +85,14 @@ class OpaqueDialog : public QObject, public AnyActionDialog
     Q_OBJECT
 
 private:
-    Q3PtrList<BodyDialog> * edits;
+    QList<BodyDialog *> * edits;
     MultiLineEdit * ocl_beh;
     MultiLineEdit * cpp_beh;
     MultiLineEdit * java_beh;
 
 public:
     void init(Q3TabDialog *, ActivityActionData *, OpaqueAction *,
-              Q3PtrList<BodyDialog> & e, bool visit);
+              QList<BodyDialog *> & e, bool visit);
     bool update(OpaqueAction *);
 
     static void post_edit_ocl(ActivityActionDialog * d, QString s);
@@ -272,14 +272,14 @@ class ValueSpecificationDialog : public QObject, public AnyActionDialog
     Q_OBJECT
 
 private:
-    Q3PtrList<BodyDialog> * edits;
+    QList<BodyDialog *> * edits;
     MultiLineEdit * ocl_val;
     MultiLineEdit * cpp_val;
     MultiLineEdit * java_val;
 
 public:
     void init(Q3TabDialog *, ActivityActionData *,
-              ValueSpecificationAction *, Q3PtrList<BodyDialog> & e,
+              ValueSpecificationAction *, QList<BodyDialog *> & e,
               bool visit);
     bool update(ValueSpecificationAction *);
 
@@ -387,7 +387,7 @@ protected:
     QStringList class_names;
     BrowserNodeList behaviors;
     QStringList behavior_names;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     OpaqueDialog opaque;
     AcceptEventDialog acceptevent;

--- a/src/dialog/ActivityDialog.cpp
+++ b/src/dialog/ActivityDialog.cpp
@@ -122,7 +122,7 @@ ActivityDialog::ActivityDialog(ActivityData * d)
         edspecification->insertStringList(list);
         edspecification->setCurrentItem((activity->get_specification() == 0)
                                         ? 0
-                                        : opers.findRef(activity->get_specification()) + 1);
+                                        : opers.indexOf(activity->get_specification()) + 1);
     }
 
     new QLabel(grid);
@@ -274,8 +274,9 @@ ActivityDialog::~ActivityDialog()
     activity->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/ActivityDialog.h
+++ b/src/dialog/ActivityDialog.h
@@ -69,7 +69,7 @@ protected:
     Q3ComboBox * edspecification;
     MultiLineEdit * comment;
     MultiLineEdit * constraint;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
     QCheckBox * readonly_cb;
     QCheckBox * singlexec_cb;
     QCheckBox * active_cb;

--- a/src/dialog/ActivityObjectDialog.cpp
+++ b/src/dialog/ActivityObjectDialog.cpp
@@ -247,8 +247,9 @@ ActivityObjectDialog::~ActivityObjectDialog()
     data->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/ActivityObjectDialog.h
+++ b/src/dialog/ActivityObjectDialog.h
@@ -60,7 +60,7 @@ protected:
     ActivityObjectData * data;
     QStringList list;
     BrowserNodeList nodes;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
     int offset;
     BrowserNode * view;
 

--- a/src/dialog/ActivityPartitionDialog.cpp
+++ b/src/dialog/ActivityPartitionDialog.cpp
@@ -190,8 +190,9 @@ ActivityPartitionDialog::~ActivityPartitionDialog()
     data->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }
@@ -257,9 +258,9 @@ void ActivityPartitionDialog::menu_represents()
     if ((bn != 0) && allowed(bn))
         m.insertItem(TR("Choose element selected in browser"), 1);
 
-    const Q3PtrList<BrowserNode> & l = BrowserNode::marked_nodes();
+    const QList<BrowserNode *> & l = BrowserNode::marked_nodes();
 
-    if ((l.count() == 1) && allowed(l.getFirst()))
+    if ((l.count() == 1) && allowed(l.first()))
         m.insertItem(TR("Choose element marked in browser"), 2);
 
     switch (m.exec(QCursor::pos())) {
@@ -272,7 +273,7 @@ void ActivityPartitionDialog::menu_represents()
         break;
 
     case 2:
-        represented = l.getFirst();
+        represented = l.first();
         break;
 
     default:

--- a/src/dialog/ActivityPartitionDialog.h
+++ b/src/dialog/ActivityPartitionDialog.h
@@ -61,7 +61,7 @@ protected:
     QCheckBox * external_cb;
     MultiLineEdit * comment;
     KeyValuesTable * kvtable;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     static QSize previous_size;
 

--- a/src/dialog/ArtifactDialog.cpp
+++ b/src/dialog/ArtifactDialog.cpp
@@ -117,8 +117,9 @@ ArtifactDialog::~ArtifactDialog()
     //data->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     if(toolbar)
     {
@@ -556,12 +557,11 @@ void ArtifactDialog::init_assoc_classes_tab()
         for (it = l.begin(); it != end; ++it)
             d.insert(*it, *it);
 
-        BrowserNode * cl;
         BrowserNodeList classes;
 
         BrowserClass::instances(classes, 0, TRUE);
 
-        for (cl = classes.first(); cl != 0; cl = classes.next())
+        foreach (BrowserNode *cl, classes)
             if ((((BrowserClass *) cl)->get_associated_artifact() == 0) &&
                 (d.find(cl) == 0))
                 lb_cl_available->insertItem(new ListBoxBrowserNode(cl, cl->full_name(TRUE)));
@@ -1863,13 +1863,12 @@ void ArtifactDialog::stereotypeFilterActivated(const QString & st)
         QString s = st.stripWhiteSpace();
         BrowserNodeList artifacts;
         BrowserNode * itself = data->browser_node;
-        BrowserNode * cp;
 
         BrowserArtifact::instances(artifacts, s);
         lb_art_available->clear();
         lb_art_associated->clear();
 
-        for (cp = artifacts.first(); cp != 0; cp = artifacts.next()) {
+        foreach (BrowserNode *cp, artifacts) {
             if (cp != itself) {
                 if (art_associated.find(cp))
                     lb_art_associated->insertItem(new ListBoxBrowserNode(cp, cp->full_name(TRUE)));

--- a/src/dialog/ArtifactDialog.h
+++ b/src/dialog/ArtifactDialog.h
@@ -65,7 +65,7 @@ protected:
     MultiLineEdit * comment;
     QMap<BrowserClass *, FormalParamsTable *> formals;	// to generate the associated
     QMap<BrowserClass *, ActualParamsTable *> actuals;	// classes definition
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     // c++
     unsigned n_cpp;

--- a/src/dialog/AttributeDialog.cpp
+++ b/src/dialog/AttributeDialog.cpp
@@ -642,8 +642,9 @@ AttributeDialog::~AttributeDialog()
     att->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     if (new_in_st)
         // new_in_st cleared by accept

--- a/src/dialog/AttributeDialog.h
+++ b/src/dialog/AttributeDialog.h
@@ -63,7 +63,7 @@ private:
     AttributeData * att;
     QStringList list;
     BrowserNodeList nodes;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
     BrowserNode * view;
     int offset;
 

--- a/src/dialog/BasicDialog.cpp
+++ b/src/dialog/BasicDialog.cpp
@@ -140,8 +140,9 @@ BasicDialog::~BasicDialog()
     data->get_browser_node()->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/BasicDialog.h
+++ b/src/dialog/BasicDialog.h
@@ -54,7 +54,7 @@ protected:
     MultiLineEdit * comment;
     KeyValuesTable * kvtable;
     QSize & previous_size;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     static void post_edit_description(BasicDialog * d, QString s);
 

--- a/src/dialog/BodyDialog.cpp
+++ b/src/dialog/BodyDialog.cpp
@@ -46,7 +46,7 @@
 QSize BodyDialog::previous_size;
 
 BodyDialog::BodyDialog(QString t, Q3TabDialog * d, post_edit pf,
-                       EditType k, QString what, Q3PtrList<BodyDialog> & edits)
+                       EditType k, QString what, QList<BodyDialog *> & edits)
     : QDialog(d, what, d->isModal(), Qt::WDestructiveClose), dlg(d), f(pf), eds(edits)
 {
     eds.append(this);

--- a/src/dialog/BodyDialog.h
+++ b/src/dialog/BodyDialog.h
@@ -45,13 +45,13 @@ protected:
     MultiLineEdit * e;
     Q3TabDialog * dlg;
     post_edit f;
-    Q3PtrList<BodyDialog> & eds;
+    QList<BodyDialog *> & eds;
 
     static QSize previous_size;
 
 public:
     BodyDialog(QString t, Q3TabDialog * d, post_edit pf,
-               EditType k, QString what, Q3PtrList<BodyDialog> & edits);
+               EditType k, QString what, QList<BodyDialog *> & edits);
     virtual ~BodyDialog();
 };
 

--- a/src/dialog/BrowserSearchDialog.cpp
+++ b/src/dialog/BrowserSearchDialog.cpp
@@ -247,9 +247,7 @@ void BrowserSearchDialog::search()
     if (! nodes.isEmpty()) {
         nodes.sort();
 
-        BrowserNode * bn;
-
-        for (bn = nodes.first(); bn != 0; bn = nodes.next())
+        foreach (BrowserNode *bn, nodes)
             results->insertItem(*(bn->pixmap(0)), bn->full_name(TRUE));
 
         selected(0);
@@ -288,9 +286,7 @@ void BrowserSearchDialog::mark_unmark()
 
 void BrowserSearchDialog::mark_them()
 {
-    BrowserNode * bn;
-
-    for (bn = nodes.first(); bn != 0; bn = nodes.next()) {
+    foreach (BrowserNode *bn, nodes) {
         if (! bn->markedp()) {
             bn->toggle_mark();  	// call update
             BrowserView::force_visible(bn);

--- a/src/dialog/ClassDialog.cpp
+++ b/src/dialog/ClassDialog.cpp
@@ -101,8 +101,10 @@ ClassDialog::~ClassDialog()
 {
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
+
     if(toolbar)
     {
         toolbar->setParent(0);
@@ -437,10 +439,8 @@ static void cpp_generate_inherit(QString & s, ClassData * cl,
     BrowserNodeList inh;
     cl->get_browser_node()->children(inh, UmlGeneralisation, UmlRealize);
 
-    Q3PtrListIterator<BrowserNode> it(inh);
-
-    while (it.current() != 0) {
-        RelationData * r = (RelationData *) it.current()->get_data();
+    foreach (BrowserNode *item, inh) {
+        RelationData * r = (RelationData *) item->get_data();
 
         if (r->get_cppdecl_a()[0]) {
             s += sep;
@@ -451,8 +451,6 @@ static void cpp_generate_inherit(QString & s, ClassData * cl,
 
             generate_mother(r->get_end_class(), TRUE, s, cl, actuals_table, nodes, node_names);
         }
-
-        ++it;
     }
 }
 
@@ -466,10 +464,8 @@ static void cpp_generate_typedef_type(QString & s, ClassData * cl,
 
     cl->get_browser_node()->children(inh, UmlGeneralisation, UmlRealize);
 
-    Q3PtrListIterator<BrowserNode> it(inh);
-
-    while (it.current() != 0) {
-        RelationData * r = (RelationData *) it.current()->get_data();
+    foreach (BrowserNode *item, inh) {
+        RelationData * r = (RelationData *) item->get_data();
         /*if (r->get_cppdecl_a()[0])*/
         {
             BrowserClass * mother = r->get_end_class();
@@ -483,8 +479,6 @@ static void cpp_generate_typedef_type(QString & s, ClassData * cl,
                 return;
             }
         }
-
-        ++it;
     }
 
     s += GenerationSettings::cpp_type(type(basetype, node_names, nodes));
@@ -951,11 +945,9 @@ static void java_generate_extends(QString & s, const QString & stereotype,
 
     cl->get_browser_node()->children(inh, UmlGeneralisation, UmlRealize);
 
-    Q3PtrListIterator<BrowserNode> it(inh);
-
-    while (it.current() != 0) {
+    foreach (BrowserNode *item, inh) {
         RelationData * r =
-            (RelationData *)((BrowserRelation *) it.current())->get_data();
+            (RelationData *)((BrowserRelation *) item)->get_data();
 
         if (r->get_javadecl_a()[0]) {
             bool gen = FALSE;
@@ -988,8 +980,6 @@ static void java_generate_extends(QString & s, const QString & stereotype,
                 generate_mother(mother, FALSE, s, cl, actuals_table, nodes, node_names);
             }
         }
-
-        ++it;
     }
 }
 
@@ -1002,11 +992,9 @@ static void java_generate_implements(QString & s, const QString & stereotype,
 
     cl->get_browser_node()->children(inh, UmlGeneralisation, UmlRealize);
 
-    Q3PtrListIterator<BrowserNode> it(inh);
-
-    while (it.current() != 0) {
+    foreach (BrowserNode *item, inh) {
         RelationData * r =
-            (RelationData *)((BrowserRelation *) it.current())->get_data();
+            (RelationData *)((BrowserRelation *) item)->get_data();
 
         if (r->get_javadecl_a()[0]) {
             BrowserClass * mother = r->get_end_class();
@@ -1024,8 +1012,6 @@ static void java_generate_implements(QString & s, const QString & stereotype,
                 generate_mother(mother, FALSE, s, cl, actuals_table, nodes, node_names);
             }
         }
-
-        ++it;
     }
 }
 
@@ -1246,11 +1232,9 @@ static void php_generate_extends(QString & s, const QString & stereotype,
 
     cl->get_browser_node()->children(inh, UmlGeneralisation, UmlRealize);
 
-    Q3PtrListIterator<BrowserNode> it(inh);
-
-    while (it.current() != 0) {
+    foreach (BrowserNode *item, inh) {
         RelationData * r =
-            (RelationData *)((BrowserRelation *) it.current())->get_data();
+            (RelationData *)((BrowserRelation *) item)->get_data();
 
         if (r->get_phpdecl_a()[0]) {
             bool gen = FALSE;
@@ -1280,8 +1264,6 @@ static void php_generate_extends(QString & s, const QString & stereotype,
                 s += mother->get_name();
             }
         }
-
-        ++it;
     }
 }
 
@@ -1293,11 +1275,9 @@ static void php_generate_implements(QString & s, const QString & stereotype,
 
     cl->get_browser_node()->children(inh, UmlGeneralisation, UmlRealize);
 
-    Q3PtrListIterator<BrowserNode> it(inh);
-
-    while (it.current() != 0) {
+    foreach (BrowserNode *item, inh) {
         RelationData * r =
-            (RelationData *)((BrowserRelation *) it.current())->get_data();
+            (RelationData *)((BrowserRelation *) item)->get_data();
 
         if (r->get_phpdecl_a()[0]) {
             BrowserClass * mother = r->get_end_class();
@@ -1314,8 +1294,6 @@ static void php_generate_implements(QString & s, const QString & stereotype,
                 s += mother->get_name();
             }
         }
-
-        ++it;
     }
 }
 
@@ -1476,10 +1454,8 @@ static void python_generate_inherit(QString & s, ClassData * cl, bool object,
 
     cl->get_browser_node()->children(inh, UmlGeneralisation, UmlRealize);
 
-    Q3PtrListIterator<BrowserNode> it(inh);
-
-    while (it.current() != 0) {
-        RelationData * r = (RelationData *) it.current()->get_data();
+    foreach (BrowserNode *item, inh) {
+        RelationData * r = (RelationData *) item->get_data();
 
         if (r->get_cppdecl_a()[0]) {
             s += sep;
@@ -1487,8 +1463,6 @@ static void python_generate_inherit(QString & s, ClassData * cl, bool object,
 
             generate_mother(r->get_end_class(), FALSE, s, cl, 0, nodes, node_names);
         }
-
-        ++it;
     }
 
     if (*sep != '(')
@@ -1673,10 +1647,8 @@ static void idl_generate_inherit(QString & s, QString st, ClassData * cl)
 
     cl->get_browser_node()->children(inh, UmlGeneralisation, UmlRealize);
 
-    Q3PtrListIterator<BrowserNode> it(inh);
-
-    while (it.current() != 0) {
-        RelationData * r = (RelationData *) it.current()->get_data();
+    foreach (BrowserNode *item, inh) {
+        RelationData * r = (RelationData *) item->get_data();
 
         if (r->get_idldecl_a()[0]) {
             BrowserClass * mother = r->get_end_class();
@@ -1713,8 +1685,6 @@ static void idl_generate_inherit(QString & s, QString st, ClassData * cl)
                 sep = ", ";
             }
         }
-
-        ++it;
     }
 }
 
@@ -2447,15 +2417,14 @@ void ActualParamsTable::generate(QString & s, ClassData * cl,
                                  BrowserNodeList & nodes,
                                  QStringList & node_names)
 {
-    ActualParamData * actual;
-    unsigned index;
+    unsigned index = 0;
+    QListIterator<ActualParamData *> it(cl->actuals);
 
-    for (actual = cl->actuals.first(), index = 0;
-         actual != 0;
-         actual = cl->actuals.next(), index += 1) {
-        if (actual->get_class() == parent)
-            // find;
+    for (index = 0; it.hasNext(); index += 1) {
+        if (it.next()->get_class() == parent) {
+            it.previous();
             break;
+        }
     }
 
     int n = ((ClassData *) parent->get_data())->get_n_formalparams();
@@ -2464,7 +2433,7 @@ void ActualParamsTable::generate(QString & s, ClassData * cl,
     bool need_space = FALSE;
 
     // progress on still present formals
-    while (actual && (nth < n) && (actual->get_class() == parent)) {
+    while (it.hasNext() && (nth < n) && (it.next()->get_class() == parent)) {
         AType t = the_type(text(index, 1).stripWhiteSpace(), node_names, nodes);
 
         if (t.type != 0) {
@@ -2501,7 +2470,6 @@ void ActualParamsTable::generate(QString & s, ClassData * cl,
         }
 
         sep = ", ";
-        actual = cl->actuals.next();
         nth += 1;
         index += 1;
     }
@@ -3117,7 +3085,7 @@ void ClassDialog::FillGuiElements(ClassData * _cl)
                         artifact->setCurrentItem(artifacts.count());
                     }
                     else
-                        artifact->setCurrentItem(artifacts.find(bc) + 1);
+                        artifact->setCurrentItem(artifacts.indexOf(bc) + 1);
                 }
                 else
                     artifact->setCurrentItem(0);
@@ -3448,16 +3416,12 @@ void ClassDialog::FillGuiElements(ClassData * _cl)
         edswitch_type->insertItem(cl->get_switch_type().get_full_type());
         edswitch_type->insertStringList(GenerationSettings::basic_types());
 
-        Q3PtrListIterator<BrowserNode> it(nodes);
-
-        while (it.current() != 0) {
+        foreach (BrowserNode *item, nodes) {
             QString st =
-                idl_stereotype(((ClassData *)(it.current()->get_data()))->get_stereotype());
+                idl_stereotype(((ClassData *)(item->get_data()))->get_stereotype());
 
             if (st == "enum")
-                edswitch_type->insertItem(it.current()->full_name(TRUE));
-
-            ++it;
+                edswitch_type->insertItem(item->full_name(TRUE));
         }
     }
 

--- a/src/dialog/ClassDialog.h
+++ b/src/dialog/ClassDialog.h
@@ -85,7 +85,7 @@ protected:
     BrowserNodeList nodes;
     QStringList node_names;
     BrowserNodeList artifacts;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     ActualParamsTable * actuals_table;
     Q3VBox * instantiate_vtab;

--- a/src/dialog/ClassInstanceDialog.cpp
+++ b/src/dialog/ClassInstanceDialog.cpp
@@ -187,7 +187,7 @@ ClassInstanceDialog::ClassInstanceDialog(ClassInstanceData * i)
         BrowserClass::instances(nodes);
         nodes.full_names(list);
         edtype->insertStringList(list);
-        edtype->setCurrentItem(nodes.find(inst->get_class()));
+        edtype->setCurrentItem(nodes.indexOf(inst->get_class()));
         connect(edtype, SIGNAL(activated(int)), this, SLOT(type_changed(int)));
     }
 
@@ -272,8 +272,9 @@ ClassInstanceDialog::~ClassInstanceDialog()
     inst->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }
@@ -339,8 +340,7 @@ void ClassInstanceDialog::menu_class()
 
             // no break
         case 1: {
-
-            if ((index = nodes.findRef(bn)) == -1) {
+            if ((index = nodes.indexOf(bn)) == -1) {
                 // new class, may be created through an other dialog
                 QStringList::Iterator iter = list.begin();
                 QStringList::Iterator iter_end = list.end();
@@ -381,13 +381,10 @@ void ClassInstanceDialog::type_changed(int i)
     atbl->setNumRows(0);
     atbl->setNumRows(attributes.count());
 
-    BrowserNode * at;
-    int index;
     Q3ValueList<SlotAttr> attrs = inst->attributes;
 
-    for (at = attributes.first(), index = 0;
-         at != 0;
-         at = attributes.next(), index += 1) {
+    int index = 0;
+    foreach (BrowserNode * at, attributes) {
         atbl->setItem(index, 0, new TableItem(atbl, Q3TableItem::Never, at->get_name()));
         atbl->setItem(index, 1, new TableItem(atbl, Q3TableItem::Never, ((BrowserNode *) at->parent())->get_name()));
 
@@ -402,6 +399,7 @@ void ClassInstanceDialog::type_changed(int i)
 
         if (it_attr == attrs.end())
             atbl->setText(index, 2, QString());
+        ++index;
     }
 
     atbl->setColumnStretchable(2, TRUE);

--- a/src/dialog/ClassInstanceDialog.h
+++ b/src/dialog/ClassInstanceDialog.h
@@ -74,7 +74,7 @@ protected:
     BrowserNodeList attributes;
     BrowserNode * cl_container;
     MultiLineEdit * comment;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
     MyTable * atbl;
     RelTable * rtbl;
     KeyValuesTable * kvtable;

--- a/src/dialog/ClassViewDialog.cpp
+++ b/src/dialog/ClassViewDialog.cpp
@@ -132,7 +132,7 @@ ClassViewDialog::ClassViewDialog(BasicData * nd)
                     deploymentview->setCurrentItem(deploymentviews.count());
                 }
                 else
-                    deploymentview->setCurrentItem(deploymentviews.find(bcv) + 1);
+                    deploymentview->setCurrentItem(deploymentviews.indexOf(bcv) + 1);
             }
             else
                 deploymentview->setCurrentItem(0);
@@ -189,8 +189,9 @@ ClassViewDialog::~ClassViewDialog()
     data->get_browser_node()->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/ClassViewDialog.h
+++ b/src/dialog/ClassViewDialog.h
@@ -54,7 +54,7 @@ protected:
     BrowserNodeList deploymentviews;
     MultiLineEdit * comment;
     KeyValuesTable * kvtable;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     static QSize previous_size;
 

--- a/src/dialog/CodAddMsgDialog.cpp
+++ b/src/dialog/CodAddMsgDialog.cpp
@@ -85,11 +85,8 @@ CodAddMsgDialog::CodAddMsgDialog(CodObjCanvas * from, CodObjCanvas * to,
 
     from->get_all_in_all_out(all_in, all_out);
 
-    ColMsg * m;
     QStringList new_ones;
-    Q3PtrListIterator<ColMsg> itout(all_out);
-
-    for (; (m = itout.current()) != 0; ++itout) {
+    foreach (ColMsg *m, all_out) {
         QString s = m->next_hierarchical_rank();
 
         if ((s.find('.') != - 1) && (ColMsg::find(s, all_out) == 0)) {
@@ -98,9 +95,7 @@ CodAddMsgDialog::CodAddMsgDialog(CodObjCanvas * from, CodObjCanvas * to,
         }
     }
 
-    Q3PtrListIterator<ColMsg> itin(all_in);
-
-    for (; (m = itin.current()) != 0; ++itin) {
+    foreach (ColMsg *m, all_in) {
         QString s = m->get_hierarchical_rank() + ".1";
 
         if ((ColMsg::find(s, all_out) == 0) && (new_ones.findIndex(s) == -1)) {

--- a/src/dialog/ColMsgTable.cpp
+++ b/src/dialog/ColMsgTable.cpp
@@ -216,10 +216,7 @@ void ColMsgTable::refresh()
 
 void ColMsgTable::refresh(ColMsgList & m)
 {
-    ColMsg * msg;
-    Q3PtrListIterator<ColMsg> it(m);
-
-    for (; (msg = it.current()) != 0; ++it) {
+    foreach (ColMsg *msg, m) {
         QString def = msg->def(FALSE, TRUE, UmlView, DefaultShowContextMode);
         CodObjCanvas * from;
         CodObjCanvas * to;
@@ -264,11 +261,7 @@ void ColMsgTable::save_list(ColMsgList & l, Q3PtrDict<ColMsgList> & saved)
     if (saved.find(&l) == 0) {
         saved.insert(&l, new ColMsgList(l));
 
-        Q3PtrListIterator<ColMsg> it(l);
-
-        for (; it.current(); ++it) {
-            ColMsg * m = it.current();
-
+        foreach (ColMsg *m, l) {
             save_list(m->get_msgs(), saved);
             save_list(m->in->get_msgs(), saved);
         }

--- a/src/dialog/ComponentDialog.cpp
+++ b/src/dialog/ComponentDialog.cpp
@@ -119,8 +119,9 @@ ComponentDialog::~ComponentDialog()
     data->get_browser_node()->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }
@@ -262,11 +263,10 @@ void ComponentDialog::rq_stereotypeFilterActivated(const QString & st)
     lb_rq_available->clear();
 
     BrowserNodeList classes;
-    BrowserNode * cl;
 
     BrowserClass::instances(classes, st, TRUE);
 
-    for (cl = classes.first(); cl != 0; cl = classes.next())
+    foreach (BrowserNode *cl, classes)
         if (rqs.findIndex((BrowserClass *) cl) == -1)
             lb_rq_available->insertItem(new ListBoxBrowserNode(cl, cl->full_name(TRUE)));
 
@@ -278,11 +278,10 @@ void ComponentDialog::pr_stereotypeFilterActivated(const QString & st)
     lb_pr_available->clear();
 
     BrowserNodeList classes;
-    BrowserNode * cl;
 
     BrowserClass::instances(classes, st, TRUE);
 
-    for (cl = classes.first(); cl != 0; cl = classes.next())
+    foreach (BrowserNode *cl, classes)
         if (prs.findIndex((BrowserClass *) cl) == -1)
             lb_pr_available->insertItem(new ListBoxBrowserNode(cl, cl->full_name(TRUE)));
 
@@ -294,11 +293,10 @@ void ComponentDialog::rz_stereotypeFilterActivated(const QString & st)
     lb_rz_available->clear();
 
     BrowserNodeList classes;
-    BrowserNode * cl;
 
     BrowserClass::instances(classes, st, TRUE);
 
-    for (cl = classes.first(); cl != 0; cl = classes.next())
+    foreach (BrowserNode *cl, classes)
         if (rzs.findIndex((BrowserClass *) cl) == -1)
             lb_rz_available->insertItem(new ListBoxBrowserNode(cl, cl->full_name(TRUE)));
 

--- a/src/dialog/ComponentDialog.h
+++ b/src/dialog/ComponentDialog.h
@@ -63,7 +63,7 @@ protected:
     LineEdit * edname;
     Q3ComboBox * edstereotype;
     MultiLineEdit * comment;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     // required classes
     Q3VBox * rq_page;

--- a/src/dialog/ConstraintDialog.cpp
+++ b/src/dialog/ConstraintDialog.cpp
@@ -175,17 +175,15 @@ ConstraintTable::ConstraintTable(QWidget * parent, ConstraintCanvas * c)
     setColumnStretchable(0, FALSE);
     setColumnStretchable(1, FALSE);
 
-    int row;
     bool v = c->indicate_visible;
     Q3ValueList<BrowserNode *> & hv = c->hidden_visible;
     BrowserNodeList & elts = c->elements;
-    BrowserNode * bn;
     QString yes = TR("  yes");
-    QString empty;
 
     elts.sort();
 
-    for (bn = elts.first(), row = 0; bn != 0; bn = elts.next(), row += 1) {
+    int row = 0;
+    foreach (BrowserNode *bn, elts) {
         if ((v) ? hv.findIndex(bn) != -1 : hv.findIndex(bn) == -1)
             setText(row, 0, yes);
 
@@ -208,6 +206,7 @@ ConstraintTable::ConstraintTable(QWidget * parent, ConstraintCanvas * c)
             // note : adjustRow(row) does nothing
             setRowHeight(row, rowHeight(row) * (n + 1));
         }
+        ++row;
     }
 
     adjustColumn(0);
@@ -246,14 +245,15 @@ void ConstraintTable::hide_inherited(ConstraintCanvas * c)
 {
     BrowserNode * cl = c->cl->get_bn();
     BrowserNodeList & elts = c->elements;
-    BrowserNode * bn;
-    int row;
     QString yes = TR("  yes");
     QString empty;
 
-    for (bn = elts.first(), row = 0; bn != 0; bn = elts.next(), row += 1)
+    int row = 0;
+    foreach (BrowserNode *bn, elts) {
         setText(row, 0,
                 ((bn == cl) || (bn->parent() == cl)) ? yes : empty);
+        ++row;
+    }
 }
 
 void ConstraintTable::update(ConstraintCanvas * c)
@@ -261,12 +261,13 @@ void ConstraintTable::update(ConstraintCanvas * c)
     Q3ValueList<BrowserNode *> & list = c->hidden_visible;
     bool empty_if_visible = !c->indicate_visible;
     BrowserNodeList & elts = c->elements;
-    BrowserNode * bn;
-    int row;
 
     list.clear();
 
-    for (bn = elts.first(), row = 0; bn != 0; bn = elts.next(), row += 1)
+    int row = 0;
+    foreach (BrowserNode *bn, elts) {
         if (text(row, 0).isEmpty() == empty_if_visible)
             list.append(bn);
+        ++row;
+    }
 }

--- a/src/dialog/DialogUtil.cpp
+++ b/src/dialog/DialogUtil.cpp
@@ -247,7 +247,7 @@ void same_width(QWidget * l1, QWidget * l2, QWidget * l3,
 }
 
 void edit(const QString & s, QString name, void * id, EditType k,
-          Q3TabDialog * d, post_edit pf, Q3PtrList<BodyDialog> & edits)
+          Q3TabDialog * d, post_edit pf, QList<BodyDialog *> & edits)
 {
     QString ed = DoumlEditor;
 
@@ -321,7 +321,7 @@ void edit(const QString & s, QString name, void * id, EditType k,
         (new BodyDialog(s, d, pf, k, name, edits))->show();
 }
 
-bool check_edits(Q3PtrList<BodyDialog> & edits)
+bool check_edits(QList<BodyDialog *> & edits)
 {
     if (edits.isEmpty())
         return TRUE;

--- a/src/dialog/DialogUtil.h
+++ b/src/dialog/DialogUtil.h
@@ -101,8 +101,8 @@ enum EditType { CppEdit, JavaEdit, PhpEdit, PythonEdit, TxtEdit };
 typedef void (* post_edit)(Q3TabDialog *, QString);
 
 extern void edit(const QString &, QString name, void * id, EditType k,
-                 Q3TabDialog * tbl, post_edit pf, Q3PtrList<BodyDialog> & edits);
-extern bool check_edits(Q3PtrList<BodyDialog> & edits);
+                 Q3TabDialog * tbl, post_edit pf, QList<BodyDialog *> & edits);
+extern bool check_edits(QList<BodyDialog *> & edits);
 
 extern AType the_type(const QString & t, const QStringList & types,
                       BrowserNodeList & nodes);

--- a/src/dialog/ExpansionRegionDialog.cpp
+++ b/src/dialog/ExpansionRegionDialog.cpp
@@ -174,8 +174,9 @@ ExpansionRegionDialog::~ExpansionRegionDialog()
     data->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/ExpansionRegionDialog.h
+++ b/src/dialog/ExpansionRegionDialog.h
@@ -58,7 +58,7 @@ protected:
     QCheckBox * must_isolate_cb;
     MultiLineEdit * comment;
     KeyValuesTable * kvtable;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     static QSize previous_size;
 

--- a/src/dialog/ExtraMemberDialog.cpp
+++ b/src/dialog/ExtraMemberDialog.cpp
@@ -277,8 +277,9 @@ ExtraMemberDialog::~ExtraMemberDialog()
     emd->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/ExtraMemberDialog.h
+++ b/src/dialog/ExtraMemberDialog.h
@@ -53,7 +53,7 @@ class ExtraMemberDialog : public Q3TabDialog
 
 protected:
     ExtraMemberData * emd;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     // uml tab
     LineEdit * edname;

--- a/src/dialog/FlowDialog.cpp
+++ b/src/dialog/FlowDialog.cpp
@@ -154,8 +154,9 @@ FlowDialog::~FlowDialog()
     flow->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/FlowDialog.h
+++ b/src/dialog/FlowDialog.h
@@ -67,7 +67,7 @@ protected:
     LineEdit * edname;
     Q3ComboBox * edstereotype;
     MultiLineEdit * comment;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     FlDialog uml;
     FlDialog cpp;

--- a/src/dialog/FragmentDialog.cpp
+++ b/src/dialog/FragmentDialog.cpp
@@ -59,7 +59,6 @@ FragmentDialog::FragmentDialog(const QStringList & defaults, QString & s,
     QLabel * lbl1;
     QLabel * lbl2;
     SmallPushButton * refer_bt;
-    BrowserNode * bn;
 
     vbox->setMargin(5);
 
@@ -86,12 +85,12 @@ FragmentDialog::FragmentDialog(const QStringList & defaults, QString & s,
     BrowserDiagram::instances(nodes, TRUE);
     diag_cb->insertItem("");
 
-    for (bn = nodes.first(); bn != 0; bn = nodes.next())
+    foreach (BrowserNode *bn, nodes)
         diag_cb->insertItem(*(bn->pixmap(0)), bn->full_name(TRUE));
 
     diag_cb->setCurrentItem((refer == 0)
                             ? 0
-                            : nodes.findRef(refer) + 1);
+                            : nodes.indexOf(refer) + 1);
     diag_cb->setSizePolicy(sp);
     hbox->addWidget(diag_cb);
 
@@ -162,7 +161,7 @@ void FragmentDialog::menu_refer()
             break;
 
         case 1:
-            diag_cb->setCurrentItem(nodes.findRef(bn) + 1);
+            diag_cb->setCurrentItem(nodes.indexOf(bn) + 1);
             break;
 
         default:

--- a/src/dialog/HideShowDialog.cpp
+++ b/src/dialog/HideShowDialog.cpp
@@ -89,16 +89,12 @@ HideShowDialog::HideShowDialog(const BrowserNodeList & a,
     subvbox->addWidget(lb_hidden = new Q3ListBox(this));
     lb_hidden->setSelectionMode(Q3ListBox::Multi);
 
-    Q3PtrListIterator<BrowserNode> it(all);
+    foreach (BrowserNode *item, all) {
+        QString def = item->get_data()->definition(TRUE, FALSE);
 
-    while (it.current() != 0) {
-        QString def = it.current()->get_data()->definition(TRUE, FALSE);
-
-        (((hidden_visible.findIndex(it.current()) == -1) ^ on_visible)
+        (((hidden_visible.findIndex(item) == -1) ^ on_visible)
          ? lb_visible : lb_hidden)
-        ->insertItem(new ListBoxBrowserNode(it.current(), def));
-
-        ++it;
+        ->insertItem(new ListBoxBrowserNode(item, def));
     }
 
     lb_visible->sort();
@@ -224,17 +220,13 @@ void HideShowDialog::hide_private()
     lb_visible->clear();
     lb_hidden->clear();
 
-    Q3PtrListIterator<BrowserNode> it(all);
-
-    while (it.current() != 0) {
-        BasicData * m = it.current()->get_data();
+    foreach (BrowserNode *item, all) {
+        BasicData * m = item->get_data();
         QString def = m->definition(TRUE, FALSE);
 
         ((((ClassMemberData *) m)->get_visibility(m->get_browser_node()) != UmlPrivate)
          ? lb_visible : lb_hidden)
-        ->insertItem(new ListBoxBrowserNode(it.current(), def));
-
-        ++it;
+        ->insertItem(new ListBoxBrowserNode(item, def));
     }
 
     lb_visible->sort();
@@ -246,19 +238,15 @@ void HideShowDialog::hide_private_protected()
     lb_visible->clear();
     lb_hidden->clear();
 
-    Q3PtrListIterator<BrowserNode> it(all);
-
-    while (it.current() != 0) {
-        BasicData * m = it.current()->get_data();
+    foreach (BrowserNode *item, all) {
+        BasicData * m = item->get_data();
         QString def = m->definition(TRUE, FALSE);
         UmlVisibility visi =
             ((ClassMemberData *) m)->get_visibility(m->get_browser_node());
 
         (((visi == UmlPublic) || (visi == UmlPackageVisibility))
          ? lb_visible : lb_hidden)
-        ->insertItem(new ListBoxBrowserNode(it.current(), def));
-
-        ++it;
+        ->insertItem(new ListBoxBrowserNode(item, def));
     }
 
     lb_visible->sort();

--- a/src/dialog/InstanceDialog.cpp
+++ b/src/dialog/InstanceDialog.cpp
@@ -78,7 +78,7 @@ InstanceDialog::InstanceDialog(Instance * i, QString w, UmlCode k)
     inst->get_types(nodes);
     nodes.full_names(list);
     edtype->insertStringList(list);
-    edtype->setCurrentItem(nodes.find(inst->get_type()));
+    edtype->setCurrentItem(nodes.indexOf(inst->get_type()));
 
     new QLabel("", grid);
     new QLabel("", grid);

--- a/src/dialog/ObjectLinkDialog.cpp
+++ b/src/dialog/ObjectLinkDialog.cpp
@@ -51,7 +51,7 @@
 QSize ObjectLinkDialog::previous_size;
 
 ObjectLinkDialog::ObjectLinkDialog(BrowserClassInstance * a, BrowserClassInstance * b,
-                                   Q3PtrList<RelationData> & l, RelationData * current,
+                                   QList<RelationData *> & l, RelationData * current,
                                    int nfirstdir)
     : QDialog(0, "object link dialog", TRUE),
       rels(l), nforward(nfirstdir), clia(a), clib(b), choozen(0), reverse(FALSE)
@@ -151,14 +151,14 @@ void ObjectLinkDialog::init(RelationData * current)
          ((ClassInstanceData *) clia->get_data())->get_class()->get_name();
     rb = clib->get_name() + QString(":") +
          ((ClassInstanceData *) clib->get_data())->get_class()->get_name();
-    Q3PtrListIterator<RelationData> iter(rels);
-    int row;
+    QListIterator<RelationData *> iter(rels);
+    int row = 0;
 
-    for (row = 0; (row != nforward) && iter.current(); ++iter, row += 1)
-        add_rel(table, iter.current(), row, ra, rb);
+    for (; (row != nforward) && iter.hasNext(); ++row)
+        add_rel(table, iter.next(), row, ra, rb);
 
-    for (; iter.current(); ++iter, row += 1)
-        add_rel(table, iter.current(), row, rb, ra);
+    for (; iter.hasNext(); ++row)
+        add_rel(table, iter.next(), row, rb, ra);
 
     ninputrels = row;
 
@@ -171,7 +171,7 @@ void ObjectLinkDialog::init(RelationData * current)
     if (current != 0) {
         // select the current relation
         Q3TableSelection sel;
-        int row = rels.findRef(current);
+        int row = rels.indexOf(current);
 
         sel.init(row, 0);
         sel.expandTo(row, 4);

--- a/src/dialog/ObjectLinkDialog.h
+++ b/src/dialog/ObjectLinkDialog.h
@@ -42,7 +42,7 @@ class ObjectLinkDialog : public QDialog
 
 public:
     ObjectLinkDialog(BrowserClassInstance * a, BrowserClassInstance * b,
-                     Q3PtrList<RelationData> & l, RelationData * current,
+                     QList<RelationData *> & l, RelationData * current,
                      int nfirstdir);
     virtual ~ObjectLinkDialog();
 
@@ -56,7 +56,7 @@ public:
 protected:
     void init(RelationData * current);
 
-    Q3PtrList<RelationData> & rels;
+    QList<RelationData *> & rels;
     int nforward;
     int ninputrels;
     BrowserClassInstance * clia;

--- a/src/dialog/OperationDialog.cpp
+++ b/src/dialog/OperationDialog.cpp
@@ -115,8 +115,9 @@ OperationDialog::~OperationDialog()
 //        oper->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     if(toolbar)
     {

--- a/src/dialog/OperationDialog.h
+++ b/src/dialog/OperationDialog.h
@@ -72,7 +72,7 @@ protected:
     ClassData * cl;
     QStringList list;
     BrowserNodeList nodes;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
     BrowserNode * view;
     AttributeData * get_of_attr;
     AttributeData * set_of_attr;

--- a/src/dialog/OperationListDialog.cpp
+++ b/src/dialog/OperationListDialog.cpp
@@ -48,7 +48,7 @@
 QSize OperationListDialog::previous_size;
 
 OperationListDialog::OperationListDialog(const char * m,
-        Q3PtrList<BrowserOperation> & l)
+        QList<BrowserOperation *> & l)
     : QDialog(0, m, TRUE)
 {
     setCaption(m);
@@ -62,7 +62,7 @@ OperationListDialog::OperationListDialog(const char * m,
     cb = new Q3ComboBox(FALSE, this);
     vbox->addWidget(cb);
 
-    for (BrowserOperation * oper = l.first(); oper; oper = l.next()) {
+    foreach (BrowserOperation *oper, l) {
         QString s = ((BrowserNode *) oper->parent())->get_name() +
                     QString("::") + oper->get_data()->definition(TRUE, FALSE);
 

--- a/src/dialog/OperationListDialog.h
+++ b/src/dialog/OperationListDialog.h
@@ -43,7 +43,7 @@ protected:
     static QSize previous_size;
 
 public:
-    OperationListDialog(const char * m, Q3PtrList<BrowserOperation> & l);
+    OperationListDialog(const char * m, QList<BrowserOperation *> & l);
     virtual ~OperationListDialog();
 
     int choosen();

--- a/src/dialog/PackageDialog.cpp
+++ b/src/dialog/PackageDialog.cpp
@@ -494,8 +494,9 @@ PackageDialog::~PackageDialog()
     pa->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/PackageDialog.h
+++ b/src/dialog/PackageDialog.h
@@ -54,7 +54,7 @@ protected:
     LineEdit * edname;
     Q3ComboBox * edstereotype;
     MultiLineEdit * comment;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     // C++
     QWidget * cppTab;

--- a/src/dialog/ParameterDialog.cpp
+++ b/src/dialog/ParameterDialog.cpp
@@ -311,8 +311,9 @@ ParameterDialog::~ParameterDialog()
     param->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/ParameterDialog.h
+++ b/src/dialog/ParameterDialog.h
@@ -60,7 +60,7 @@ protected:
     ParameterData * param;
     QStringList list;
     BrowserNodeList nodes;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
     BrowserNode * view;
     int offset;
 

--- a/src/dialog/ParameterSetDialog.cpp
+++ b/src/dialog/ParameterSetDialog.cpp
@@ -99,8 +99,9 @@ ParameterSetDialog::~ParameterSetDialog()
     data->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/ParameterSetDialog.h
+++ b/src/dialog/ParameterSetDialog.h
@@ -59,7 +59,7 @@ protected:
     LineEdit * edname;
     Q3ComboBox * edstereotype;
     MultiLineEdit * comment;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     // associated classes
     Q3ListBox * lb_available;

--- a/src/dialog/PinDialog.cpp
+++ b/src/dialog/PinDialog.cpp
@@ -298,8 +298,9 @@ PinDialog::~PinDialog()
     pin->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/PinDialog.h
+++ b/src/dialog/PinDialog.h
@@ -60,7 +60,7 @@ protected:
     PinData * pin;
     QStringList list;
     BrowserNodeList nodes;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
     BrowserNode * view;
     int offset;
 

--- a/src/dialog/PseudoStateDialog.cpp
+++ b/src/dialog/PseudoStateDialog.cpp
@@ -167,7 +167,7 @@ PseudoStateDialog::PseudoStateDialog(PseudoStateData * ps)
             edreference->insertStringList(reflist);
             edreference->setCurrentItem((ref == 0)
                                         ? 0
-                                        : pseudostates.findRef(ref) + 1);
+                                        : pseudostates.indexOf(ref) + 1);
         }
     }
     else
@@ -217,8 +217,9 @@ PseudoStateDialog::~PseudoStateDialog()
     pst->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/PseudoStateDialog.h
+++ b/src/dialog/PseudoStateDialog.h
@@ -60,7 +60,7 @@ protected:
     Q3ComboBox * edreference;
     MultiLineEdit * comment;
     KeyValuesTable * kvtable;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     static QSize previous_size;
 

--- a/src/dialog/ReferenceDialog.cpp
+++ b/src/dialog/ReferenceDialog.cpp
@@ -115,35 +115,33 @@ void ReferenceDialog::compute()
 {
     QApplication::setOverrideCursor(Qt::waitCursor);
 
-    Q3PtrList<BrowserNode> l;
-    BrowserNode * bn;
+    QList<BrowserNode *> l;
 
     nodes.clear();
     results->clear();
     target->referenced_by(l);
 
-    for (bn = l.first(); bn; bn = l.next())
+    foreach (BrowserNode * bn, l)
         nodes.append(bn);
 
     nodes.sort();
 
     // remove duplicats
-    nodes.first();
-
-    while ((bn = nodes.current()) != 0)
-        if (bn == nodes.next())
-            nodes.remove();
+    BrowserNode *prevNode = 0;
+    foreach (BrowserNode * bn, l) {
+        if (prevNode == bn)
+            nodes.removeOne(bn);
+    }
 
     QStringList names;
 
     nodes.full_names(names);
 
-    QStringList::Iterator it;
-
-    for (bn = nodes.first(), it = names.begin();
-         bn;
-         bn = nodes.next(), ++it)
+    QStringList::Iterator it = names.begin();
+    foreach (BrowserNode * bn, nodes) {
         results->insertItem(*(bn->pixmap(0)), *it);
+        ++it;
+    }
 
     selected((nodes.isEmpty()) ? -1 : 0);
 
@@ -178,9 +176,7 @@ void ReferenceDialog::mark_unmark()
 
 void ReferenceDialog::mark_them()
 {
-    BrowserNode * bn;
-
-    for (bn = nodes.first(); bn != 0; bn = nodes.next()) {
+    foreach (BrowserNode *bn, nodes) {
         if (! bn->markedp()) {
             bn->toggle_mark();  	// call update
             BrowserView::force_visible(bn);

--- a/src/dialog/RelatedElementsDialog.cpp
+++ b/src/dialog/RelatedElementsDialog.cpp
@@ -162,14 +162,9 @@ void RelatedElementsDialog::accept()
 
     do {
         BrowserNodeList newones;
-        Q3PtrListIterator<BrowserNode> it(added);
-
-        for (; it.current() != 0; ++it) {
-            BrowserNode * e = (BrowserNode *) it.current();
-            BrowserNode * bn;
-
+        foreach (BrowserNode *e, added) {
             if (referenced_rb->isChecked()) {
-                for (bn = (BrowserNode *) e->firstChild();
+                for (BrowserNode *bn = (BrowserNode *) e->firstChild();
                      bn != 0;
                      bn = (BrowserNode *) bn->nextSibling()) {
                     if (! bn->deletedp()) {

--- a/src/dialog/RelationDialog.cpp
+++ b/src/dialog/RelationDialog.cpp
@@ -456,8 +456,9 @@ RelationDialog::~RelationDialog()
     rel->start->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/RelationDialog.h
+++ b/src/dialog/RelationDialog.h
@@ -160,7 +160,7 @@ protected:
     Q3GroupBox * php_b;
     Q3GroupBox * python_b;
     Q3GroupBox * idl_b;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
     BrowserNode * view;
     int offset;
 

--- a/src/dialog/SimpleRelationDialog.cpp
+++ b/src/dialog/SimpleRelationDialog.cpp
@@ -152,8 +152,9 @@ SimpleRelationDialog::~SimpleRelationDialog()
     rel->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/SimpleRelationDialog.h
+++ b/src/dialog/SimpleRelationDialog.h
@@ -49,7 +49,7 @@ protected:
     Q3ComboBox * edstereotype;
     MultiLineEdit * comment;
     KeyValuesTable * kvtable;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     static QSize previous_size;
 

--- a/src/dialog/StateActionDialog.cpp
+++ b/src/dialog/StateActionDialog.cpp
@@ -180,8 +180,9 @@ StateActionDialog::~StateActionDialog()
     action->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/StateActionDialog.h
+++ b/src/dialog/StateActionDialog.h
@@ -55,7 +55,7 @@ protected:
     StateActionData * action;
     Q3ComboBox * edstereotype;
     MultiLineEdit * comment;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     QWidget * umltab;
     QWidget * cppTab;

--- a/src/dialog/StateDialog.cpp
+++ b/src/dialog/StateDialog.cpp
@@ -123,7 +123,7 @@ StateDialog::StateDialog(StateData * d)
         edspecification->insertStringList(speclist);
         edspecification->setCurrentItem((state->get_specification() == 0)
                                         ? 0
-                                        : opers.findRef(state->get_specification()) + 1);
+                                        : opers.indexOf(state->get_specification()) + 1);
     }
 
     switch (((BrowserNode *) bn->parent())->get_type()) {
@@ -148,16 +148,14 @@ StateDialog::StateDialog(StateData * d)
                 if (((BrowserState *) bn)->can_reference()) {
                     BrowserState::instances(states, TRUE);
 
-                    BrowserNode * st = states.first();
+                    QMutableListIterator<BrowserNode *> it(states);
 
-                    while (st != 0) {
-                        if (!((BrowserState *) bn)->can_reference((BrowserState *) st) ||
-                            ((BrowserState *) st)->is_ref()) {
-                            states.remove();
-                            st = states.current();
+                    while (it.hasNext()) {
+                        BrowserState *state = (BrowserState *)it.next();
+                        if (!((BrowserState *) bn)->can_reference(state) ||
+                            state->is_ref()) {
+                            it.remove();
                         }
-                        else
-                            st = states.next();
                     }
                 }
                 else
@@ -167,7 +165,7 @@ StateDialog::StateDialog(StateData * d)
                 edreference->insertStringList(reflist);
                 edreference->setCurrentItem((state->get_reference() == 0)
                                             ? 0
-                                            : states.findRef(state->get_reference()) + 1);
+                                            : states.indexOf(state->get_reference()) + 1);
 
                 connect(edreference, SIGNAL(activated(int)), this, SLOT(ed_ref_activated(int)));
             }
@@ -243,8 +241,9 @@ StateDialog::~StateDialog()
     state->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/StateDialog.h
+++ b/src/dialog/StateDialog.h
@@ -74,7 +74,7 @@ protected:
     Q3ComboBox * edreference;
     QCheckBox * active_cb;
     MultiLineEdit * comment;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     QWidget * ocltab;
     QWidget * cppTab;

--- a/src/dialog/TransitionDialog.cpp
+++ b/src/dialog/TransitionDialog.cpp
@@ -157,8 +157,9 @@ TransitionDialog::~TransitionDialog()
     rel->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/TransitionDialog.h
+++ b/src/dialog/TransitionDialog.h
@@ -68,7 +68,7 @@ protected:
     QCheckBox * internal_cb;
     Q3ComboBox * edstereotype;
     MultiLineEdit * comment;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     QWidget * ocltab;
     QWidget * cppTab;

--- a/src/dialog/UseCaseDialog.cpp
+++ b/src/dialog/UseCaseDialog.cpp
@@ -143,8 +143,9 @@ UseCaseDialog::~UseCaseDialog()
     uc->browser_node->edit_end();
     previous_size = size();
 
-    while (!edits.isEmpty())
-        edits.take(0)->close();
+    foreach (BodyDialog *dialog, edits)
+        dialog->close();
+    edits.clear();
 
     close_dialog(this);
 }

--- a/src/dialog/UseCaseDialog.h
+++ b/src/dialog/UseCaseDialog.h
@@ -53,7 +53,7 @@ protected:
     MultiLineEdit * extension_points;
     MultiLineEdit * comment;
     KeyValuesTable * kvtable;
-    Q3PtrList<BodyDialog> edits;
+    QList<BodyDialog *> edits;
 
     static QSize previous_size;
 

--- a/src/misc/Labeled.cpp
+++ b/src/misc/Labeled.cpp
@@ -189,7 +189,7 @@ struct NeedChange {
     NeedChange(IdDict<void> & d, int & id, void * e) : dict(d), ident(id), elt(e) {}
 };
 
-static Q3PtrList<NeedChange> MustBeRenumered;
+static QList<NeedChange *> MustBeRenumered;
 
 void will_change_id(IdDict<void> & d, int & id, void * x)
 {
@@ -201,7 +201,7 @@ void do_change_shared_ids()
     int user = user_id();
 
     while (!MustBeRenumered.isEmpty()) {
-        NeedChange * x = MustBeRenumered.take(0);
+        NeedChange * x = MustBeRenumered.takeFirst();
 
         x->ident = new_place(x->dict, user, x->elt);
         delete x;

--- a/src/misc/ProfiledStereotypes.cpp
+++ b/src/misc/ProfiledStereotypes.cpp
@@ -945,7 +945,7 @@ static void recompute_st_list()
     BrowserClass::instances(l, "stereotype", TRUE);
 
     while (! l.isEmpty()) {
-        BrowserClass * cl = (BrowserClass *) l.take(0);
+        BrowserClass * cl = (BrowserClass *) l.takeFirst();
         BrowserNode * pf = (BrowserNode *) cl->parent()->parent();
 
         if ((pf->get_type() == UmlPackage) &&

--- a/src/misc/myio.cpp
+++ b/src/misc/myio.cpp
@@ -1528,7 +1528,6 @@ void delete_backup(QDir & d)
     QFileInfoList l = d.entryInfoList(s);
 
     if (!l.empty()) {
-        //Q3PtrListIterator<QFileInfo> it(l);
         QFileInfoList::iterator it = l.begin(); //[lgfreitas] above iterator was not working.
         //QFileInfo fi;
 

--- a/src/tool/ToolCom.cpp
+++ b/src/tool/ToolCom.cpp
@@ -120,8 +120,8 @@ void Socket::data_received()
 
 //
 
-Q3PtrList<ToolCom> ToolCom::used;
-Q3PtrList<ToolCom> ToolCom::unused;
+QList<ToolCom *> ToolCom::used;
+QList<ToolCom *> ToolCom::unused;
 int ToolCom::exitvalue;
 
 ToolCom::ToolCom()
@@ -167,7 +167,7 @@ int ToolCom::run(const char * cmd, BrowserNode * bn,
 
     ToolCom * com = (unused.isEmpty())
             ? new ToolCom
-            : unused.take(0);
+            : unused.takeFirst();
 
     com->DisconnectExternalProcess();
 
@@ -213,10 +213,8 @@ int exit_value()
 
 bool ToolCom::is_running(int id)
 {
-    Q3PtrListIterator<ToolCom> it(used);
-
-    for (; it.current(); ++it)
-        if (it.current()->id == id)
+    foreach (ToolCom *item, used)
+        if (item->id == id)
             return TRUE;
 
     return FALSE;
@@ -748,17 +746,16 @@ void ToolCom::data_received(Socket * who)
                         break;
 
                     case allMarkedCmd: {
-                        Q3PtrList<BrowserNode> marked = BrowserNode::marked_nodes();
+                        QList<BrowserNode *> marked = BrowserNode::marked_nodes();
                         unsigned n = 0;
-                        BrowserNode * bn;
 
-                        for (bn = marked.first(); bn != 0; bn = marked.next())
+                        foreach (BrowserNode *bn, marked)
                             if (bn->api_compatible(api_format(true)))
                                 n += 1;
 
                         write_unsigned(n);
 
-                        for (bn = marked.first(); bn != 0; bn = marked.next())
+                        foreach (BrowserNode *bn, marked)
                             if (bn->api_compatible(api_format(true)))
                                 bn->write_id(this);
                     }

--- a/src/tool/ToolCom.h
+++ b/src/tool/ToolCom.h
@@ -48,8 +48,8 @@ class ToolCom  : public QObject
     Q_OBJECT
 
 protected:
-    static Q3PtrList<ToolCom> used;
-    static Q3PtrList<ToolCom> unused;
+    static QList<ToolCom *> used;
+    static QList<ToolCom *> unused;
     static int exitvalue;
 
     bool start;


### PR DESCRIPTION
I've separated virtual method refactoring to first commit. This method overriden in many nodes, but used only twice; so I simplified this method in order to remove Q3PtrList/QList dependency at all.

Second commit have no changes in logic and was fully reviewed to fix typos. In most cases it unifies lists processing by using "foreach" macro.
