### PR TITLE
Genplugouts: fixed build on Linux.

### DIFF
--- a/genplugouts/Xmi2Generator/Xmi2Generator.pro
+++ b/genplugouts/Xmi2Generator/Xmi2Generator.pro
@@ -2,14 +2,15 @@ TEMPLATE    = app
 TARGET        = gxmi2
 CONFIG(Debug, Debug|Release) {
     CONFIG -= Debug Release
-    CONFIG += qt warn_on Debug precompile_header
+    CONFIG += qt warn_on Debug
     QMAKE_POST_LINK = " "
 }
 CONFIG(Release, Debug|Release) {
     CONFIG -= Debug Release
-    CONFIG += qt Release precompile_header
+    CONFIG += qt Release
     QMAKE_POST_LINK = " "
 }
+CONFIG += precompile_header
 DEFINES        = WITHCPP WITHJAVA WITHIDL WITHPYTHON WITHPHP
 QMAKE_CXXFLAGS += -std=gnu++11
 PRECOMPILED_HEADER += ../../src/misc/mystr.h

--- a/genplugouts/plugouts.pro
+++ b/genplugouts/plugouts.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += BrowserSort CppUtilities Deploy FileControl GlobalChange HtmlDoc UseCaseWizard Xmi2Generator xmi2import
+SUBDIRS += BrowserSort CppUtilities deploy FileControl GlobalChange HtmlDoc usecasewizard Xmi2Generator xmi2import
 
 CODECFORTR      = UTF-8
 CODECFORSRC     = UTF-8

--- a/genplugouts/usecasewizard/TabDialog.cpp
+++ b/genplugouts/usecasewizard/TabDialog.cpp
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <q3vbox.h>
 #include <qlabel.h>
-#include <Q3TextEdit.h>
+#include <Q3TextEdit>
 #include <q3groupbox.h>
 #include <qtextcodec.h>
 #include <qdir.h>

--- a/genplugouts/xmi2import/xmi2import.pro
+++ b/genplugouts/xmi2import/xmi2import.pro
@@ -2,16 +2,17 @@ TEMPLATE    = app
 TARGET        = ixmi2
 CONFIG(Debug, Debug|Release) {
     CONFIG -= Debug Release
-    CONFIG += qt warn_on Debug precompile_header
+    CONFIG += qt warn_on Debug
     QMAKE_POST_LINK = " "
 }
 CONFIG(Release, Debug|Release) {
     CONFIG -= Debug Release
-    CONFIG += qt Release precompile_header
+    CONFIG += qt Release
     QMAKE_POST_LINK = " "
 }
 DEFINES        = WITHCPP WITHJAVA WITHIDL WITHPHP WITHPYTHON BooL=bool
 PRECOMPILED_HEADER += ../../src/misc/mystr.h
+CONFIG += precompile_header
 HEADERS        = ./UmlActivityPartition.h \
           ./UmlBaseNode.h \
           ./UmlPackage.h \


### PR DESCRIPTION
Fixed issues with subdirs names case and disappeared CONFIG qmake variable setting.
