### PR TITLE
Sequence diagram duration object position

### DIFF
--- a/src/diagram/SdDurationCanvas.cpp
+++ b/src/diagram/SdDurationCanvas.cpp
@@ -114,7 +114,7 @@ void SdDurationCanvas::change_scale()
 
 void SdDurationCanvas::update_hpos()
 {
-    moveBy(support->sub_x(width()), 100000);
+    moveBy(support->sub_x(width()) - x(), 100000);
 
     foreach (SdDurationCanvas *canvas, durations)
         canvas->update_hpos();


### PR DESCRIPTION
Sequence diagram duration object position was not calculated correctly.
It is fixed.