### PR TITLE
Some fixes

### DIFF
--- a/src/CppReverse/main.cpp
+++ b/src/CppReverse/main.cpp
@@ -42,8 +42,10 @@
 
 int main(int argc, char ** argv)
 {
+#if 1
     if (argc != 2)
         return 0;
+#endif
     //QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));
     //QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));
 #ifdef DEBUG
@@ -60,7 +62,11 @@ int main(int argc, char ** argv)
     QLOG_INFO() << "Starting the log";
 #endif
     //QTest::qSleep(7000);
+#if 1
     if (UmlCom::connect(WrapperStr(argv[1]).operator QString().toUInt())) {
+#else
+    if (UmlCom::connect(5000)) {
+#endif
         try {
             //UmlCom::with_ack(FALSE);
             UmlCom::trace("<b>C++ reverse</b> release 2.15<br>");

--- a/src/CustomWidgets/quickedit.cpp
+++ b/src/CustomWidgets/quickedit.cpp
@@ -401,7 +401,7 @@ void QuickEdit::AddOperation()
     if(!classNode)
         return;
     BrowserOperation* newOperation = static_cast<BrowserOperation*>(classNode->addOperation());
-    classNode->move(newOperation, currentNode);
+    //classNode->move(newOperation, currentNode);
     classNode->select_in_browser();
     QModelIndex parentIndex;
     TreeItemInterface* parent;
@@ -467,7 +467,7 @@ void QuickEdit::AddAttribute()
         newAttribute = static_cast<BrowserAttribute*>(classNode->addEnumItem());
     else
         newAttribute = static_cast<BrowserAttribute*>(classNode->addAttribute());
-    classNode->move(newAttribute, currentNode);
+    //classNode->move(newAttribute, currentNode);
     classNode->select_in_browser();
     QModelIndex parentIndex;
     TreeItemInterface* parent;

--- a/src/browser/BrowserClassView.cpp
+++ b/src/browser/BrowserClassView.cpp
@@ -352,6 +352,8 @@ void BrowserClassView::exec_menu_choice(int rank)
         if (d == 0)
             return;
 
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
     break;
@@ -362,7 +364,8 @@ void BrowserClassView::exec_menu_choice(int rank)
 
         if (d == 0)
             return;
-
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
     break;
@@ -373,7 +376,8 @@ void BrowserClassView::exec_menu_choice(int rank)
 
         if (d == 0)
             return;
-
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
     break;
@@ -543,7 +547,8 @@ void BrowserClassView::exec_menu_choice(int rank)
 
         if (d == 0)
             return;
-
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
     break;

--- a/src/browser/BrowserOperation.cpp
+++ b/src/browser/BrowserOperation.cpp
@@ -338,6 +338,34 @@ BrowserOperation * BrowserOperation::new_one(QString s, BrowserNode * p)
 
     d->set_browser_node(result, TRUE);
 
+
+    QString nameOfClassNode = p->get_name();
+
+    //if constructor
+    int lastIndexOfConstructor = 0;
+    while(BrowserNode *node = (BrowserNode *)p->child(lastIndexOfConstructor))
+    {
+        if(nameOfClassNode == node->get_name())
+        {
+            lastIndexOfConstructor++;
+        }
+        else
+            break;
+    }
+    if(nameOfClassNode == s)
+    {
+        p->removeChild(result);
+        p->insertChild(lastIndexOfConstructor,result);
+    }
+    //destructor
+    else if(("~" + nameOfClassNode) == s)
+    {
+
+        p->removeChild(result);
+        p->insertChild(lastIndexOfConstructor,result);
+    }
+
+
     return result;
 }
 

--- a/src/browser/BrowserUseCase.cpp
+++ b/src/browser/BrowserUseCase.cpp
@@ -299,6 +299,8 @@ void BrowserUseCase::exec_menu_choice(int rank)
         if (d == 0)
             return;
 
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;
@@ -309,7 +311,8 @@ void BrowserUseCase::exec_menu_choice(int rank)
 
         if (d == 0)
             return;
-
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;
@@ -320,7 +323,8 @@ void BrowserUseCase::exec_menu_choice(int rank)
 
         if (d == 0)
             return;
-
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;
@@ -420,7 +424,8 @@ void BrowserUseCase::exec_menu_choice(int rank)
 
         if (d == 0)
             return;
-
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;
@@ -435,7 +440,8 @@ void BrowserUseCase::exec_menu_choice(int rank)
 
         if (d == 0)
             return;
-
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;

--- a/src/browser/BrowserUseCaseView.cpp
+++ b/src/browser/BrowserUseCaseView.cpp
@@ -264,6 +264,8 @@ void BrowserUseCaseView::exec_menu_choice(int rank)
         if (d == 0)
             return;
 
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;
@@ -275,6 +277,8 @@ void BrowserUseCaseView::exec_menu_choice(int rank)
         if (d == 0)
             return;
 
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;
@@ -286,6 +290,8 @@ void BrowserUseCaseView::exec_menu_choice(int rank)
         if (d == 0)
             return;
 
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;
@@ -399,6 +405,8 @@ void BrowserUseCaseView::exec_menu_choice(int rank)
         if (d == 0)
             return;
 
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;
@@ -441,6 +449,8 @@ void BrowserUseCaseView::exec_menu_choice(int rank)
         if (d == 0)
             return;
 
+        removeChild(d);
+        insertChild(0,d);
         d->select_in_browser();
     }
         break;

--- a/src/diagram/NoteCanvas.cpp
+++ b/src/diagram/NoteCanvas.cpp
@@ -470,10 +470,10 @@ void NoteCanvas::read_internal(char *& st)
     stream.setCodec(codec);
     QByteArray ba;
     stream   >> ba;
-    QString temp = QString::fromLocal8Bit(ba);
+    //QString temp = QString::fromLocal8Bit(ba);
     char* test = read_string(st);
-    Q_UNUSED(test);
-    note = temp;
+    //Q_UNUSED(test);
+    note = test;
 
 
     char * k = read_keyword(st);

--- a/src/dialog/RelationDialog.cpp
+++ b/src/dialog/RelationDialog.cpp
@@ -451,7 +451,7 @@ RelationDialog::RelationDialog(RelationData * r)
     edTypeActivated(edtype->currentIndex());
 
     connect(m_tabWidget, SIGNAL(currentChanged(int)),
-            this, SLOT(update_all_tabs(int));
+            this, SLOT(update_all_tabs(int)));
 
     open_dialog(this);
 }

--- a/src/dialog/RelationDialog.cpp
+++ b/src/dialog/RelationDialog.cpp
@@ -450,8 +450,8 @@ RelationDialog::RelationDialog(RelationData * r)
 
     edTypeActivated(edtype->currentIndex());
 
-    connect(m_tabWidget, SIGNAL(currentChanged(QWidget *)),
-            this, SLOT(update_all_tabs(QWidget *)));
+    connect(m_tabWidget, SIGNAL(currentChanged(int)),
+            this, SLOT(update_all_tabs(int));
 
     open_dialog(this);
 }

--- a/src/dialog/SourceDialog.cpp
+++ b/src/dialog/SourceDialog.cpp
@@ -54,9 +54,8 @@ bool NumberedMultiLineEdit::event(QEvent * e)
     bool r = MultiLineEdit::event(e);
     int l;
     int c;
-#ifdef habip
-    getCursorPosition(&l, &c);
-#endif
+    l = textCursor().blockNumber();
+    c = textCursor().columnNumber();
 
     if ((c != old_c) || (l != old_l)) {
         old_c = c;
@@ -73,6 +72,7 @@ SourceDialog::SourceDialog(QString p, BooL & flg, unsigned & edn)
     : QDialog(0),
       path(p), edited(flg), edition_number(edn)
 {
+    setAttribute(Qt::WA_DeleteOnClose);
     QFileInfo fi(p);
 
     setWindowTitle(fi.fileName());

--- a/src/douml.pro
+++ b/src/douml.pro
@@ -571,7 +571,7 @@ Debug {
 QMAKE_CXXFLAGS += -std=gnu++11
 mac:QMAKE_CXXFLAGS += -mmacosx-version-min=10.7 -stdlib=libc++
 mac:LIBS += -lc++
-LIBS += -L../bin -lUniversalModels
+LIBS += -L../bin -lUniversalModels -lz
 RESOURCES += icons.qrc ../douml.qrc
 
 INCLUDEPATH += $${PWD}

--- a/src/misc/GenerateTypeId.cpp
+++ b/src/misc/GenerateTypeId.cpp
@@ -11,8 +11,10 @@
 
 #include <string>
 #include <unordered_map>
-#ifdef habip
+#ifdef _USE_BOOST_
 #include <boost/crc.hpp>
+#else
+#include <zlib.h>
 #endif
 #include <cassert>
 #include <cstring>
@@ -91,8 +93,8 @@ int GenerateCrcChecksum
     if (checksumSize == 0)
         return 0;
 
-    int numberOfBytesToCopy;
-    #ifdef habip
+    int numberOfBytesToCopy = checksumSize;
+    #ifdef _USE_BOOST_
     boost::crc_32_type crcGenerator;
     int dataSize = std::strlen(data) * sizeof(uint8_t) / sizeof(char);
     crcGenerator.process_bytes(data, dataSize);
@@ -103,7 +105,14 @@ int GenerateCrcChecksum
     for (int i = 0; i < numberOfBytesToCopy; ++i) {
         (*checksum)[i] = crcAsByteArray[i];
     }
-#endif
+    #else
+    unsigned long  crc = crc32(0L, Z_NULL, 0);
+    crc = crc32(crc, (const unsigned char*)data, strlen(data));
+    uint8_t * crcAsByteArray = reinterpret_cast<uint8_t *>(&crc);
+    for (int i = 0; i < numberOfBytesToCopy; ++i) {
+        (*checksum)[i] = crcAsByteArray[i];
+    }
+    #endif
     return numberOfBytesToCopy;
 }
 }

--- a/src/tool/ToolCom.cpp
+++ b/src/tool/ToolCom.cpp
@@ -217,7 +217,9 @@ int ToolCom::run(const char * cmd, BrowserNode * bn,
     com->externalProcess->start(QCoreApplication::applicationDirPath() + "/" + command, arguments);
 #endif
 #ifdef Q_OS_WIN
+#if 1
     com->externalProcess->start(command, arguments);
+#endif
 #endif
     qDebug() << "error was:" << com->externalProcess->error();
     com->start = TRUE;

--- a/src/tool/ToolCom.cpp
+++ b/src/tool/ToolCom.cpp
@@ -265,9 +265,6 @@ unsigned ToolCom::bind(unsigned port)
     else
         while (!listen_sock->listen(ha, port))
             port += 1;
-#ifdef habip
-    listen_sock->listen(1);
-#endif
     return port;
 }
 


### PR DESCRIPTION
1. in QuickEdit dialog newly added attribute or operation was moving to upper browsernodes. Fixed.
2. Because of Crc32 related parts was commented, it was not possible to use quickedit dialog. Crc32 is uncommented with zlib implementation option instead of boost. #8 
3.  notecanvas having note including double quote chracter showing fixed. #132, #76

4. opening help docs fixed

5 source dialog line/column info corrected

6. Constructor/destructor moved to top of class #110

7. Newly created diagrams moved to top of classview #111

Some issues to review for closing (maybe indirect fixes) #15, #33, #39, #53, #77, #78, #79, #116, #121, #124