### PR TITLE
Some fixes and new features

### DIFF
--- a/genplugouts/gpro/gpro.pro
+++ b/genplugouts/gpro/gpro.pro
@@ -1,6 +1,6 @@
 TEMPLATE	= app
 TARGET		= gpro
-CONFIG        += debug warn_on qt
+CONFIG        += warn_on qt
 DEFINES        = WITHCPP WITHJAVA WITHPHP WITHPYTHON WITHIDL TRUE=true FALSE=false
 HEADERS		= ./PackageGlobalCmd.h \
 		  ./UmlBaseItem.h \

--- a/genplugouts/import_rose/import_rose.pro
+++ b/genplugouts/import_rose/import_rose.pro
@@ -1,6 +1,6 @@
 TEMPLATE    = app
 TARGET        = irose
-CONFIG        += debug warn_on qt
+CONFIG        += warn_on qt
 DEFINES        = WITHCPP WITHJAVA WITHIDL  WITHPHP WITHPYTHON TRUE=true FALSE=false
 HEADERS        = ./UmlDeploymentView.h \
           ./UmlTypeSpec.h \

--- a/genplugouts/singleton/singleton.pro
+++ b/genplugouts/singleton/singleton.pro
@@ -1,6 +1,6 @@
 TEMPLATE	= app
 TARGET		= singleton
-CONFIG		+= debug warn_on qt
+CONFIG		+= warn_on qt
 DEFINES		= WITHCPP WITHJAVA WITHIDL FALSE=false TRUE=true
 HEADERS		= ./UmlBaseOperation.h \
 		  ./JavaSettings.h \

--- a/genplugouts/sm/sm.pro
+++ b/genplugouts/sm/sm.pro
@@ -1,6 +1,6 @@
 TEMPLATE	= app
 TARGET		= stmgen
-CONFIG		+= debug warn_on qt
+CONFIG		+= warn_on qt
 DEFINES		= WITHCPP FALSE=false TRUE=true TRACE
 HEADERS		= ./UmlBaseRelation.h \
 		  ./UmlStateAction.h \

--- a/genplugouts/uml_projection/uml_projection.pro
+++ b/genplugouts/uml_projection/uml_projection.pro
@@ -1,6 +1,6 @@
 TEMPLATE	= app
 TARGET		= uml_proj
-CONFIG		+= debug warn_on qt
+CONFIG		+= warn_on qt
 DEFINES		= WITHCPP WITHJAVA WITHIDL WITHPHP WITHPYTHON BooL=bool FALSE=false  TRUE=true
 HEADERS		= ./UmlBaseExpansionNode.h \
 		  ./UmlChoicePseudoState.h \

--- a/genplugouts/xmi/xmi.pro
+++ b/genplugouts/xmi/xmi.pro
@@ -1,6 +1,6 @@
 TEMPLATE    = app
 TARGET        = gxmi
-CONFIG        += debug warn_on qt
+CONFIG        += warn_on qt
 DEFINES        = WITHCPP WITHJAVA WITHIDL TRUE=true FALSE=false
 HEADERS        = ./UmlBaseFinalState.h \
           ./UmlBaseAttribute.h \

--- a/src/Generators.pro
+++ b/src/Generators.pro
@@ -1,5 +1,18 @@
 TEMPLATE = subdirs
-SUBDIRS += CppGenerator CppReverse CppRoundtrip IdlGenerator JavaCat JavaGenerator JavaReverse JavaRoundtrip PhpGenerator PhpReverse PythonGenerator RoundtripBody 
+SUBDIRS += CppGenerator\
+        CppReverse\
+        CppRoundtrip\
+        IdlGenerator\
+        JavaCat\
+        JavaGenerator\
+        JavaReverse\
+        JavaRoundtrip\
+        PhpGenerator\
+        PhpReverse\
+        PythonGenerator\
+        RoundtripBody\
+        ProjectControl\
+        ProjectSynchro
 
 CODECFORTR      = UTF-8
 CODECFORSRC     = UTF-8

--- a/src/PlugOutUpgrade/UmlClass.cpp
+++ b/src/PlugOutUpgrade/UmlClass.cpp
@@ -583,7 +583,7 @@ UmlRelation * UmlClass::add_vect_assoc(const char * name, aVisibility v, UmlClas
 
 UmlOperation * UmlClass::get_operation(const char * who)
 {
-    const Q3PtrVector<UmlItem> ch = children();
+    const QVector<UmlItem*> ch = children();
 
     for (unsigned i = 0; i != ch.size(); i += 1)
         if ((ch[i]->kind() == anOperation) &&
@@ -595,7 +595,7 @@ UmlOperation * UmlClass::get_operation(const char * who)
 
 UmlAttribute * UmlClass::get_attribute(const char * who)
 {
-    const Q3PtrVector<UmlItem> ch = children();
+    const QVector<UmlItem*> ch = children();
 
     for (unsigned i = 0; i != ch.size(); i += 1)
         if ((ch[i]->kind() == anAttribute) &&
@@ -607,7 +607,7 @@ UmlAttribute * UmlClass::get_attribute(const char * who)
 
 UmlRelation * UmlClass::get_relation(aRelationKind k, const char * who)
 {
-    const Q3PtrVector<UmlItem> ch = children();
+    const QVector<UmlItem*> ch = children();
 
     for (unsigned i = 0; i != ch.size(); i += 1) {
         if (ch[i]->kind() == aRelation) {
@@ -624,7 +624,7 @@ UmlRelation * UmlClass::get_relation(aRelationKind k, const char * who)
 
 UmlRelation * UmlClass::get_relation(const char * who)
 {
-    const Q3PtrVector<UmlItem> ch = children();
+    const QVector<UmlItem*> ch = children();
 
     for (unsigned i = 0; i != ch.size(); i += 1) {
         if (ch[i]->kind() == aRelation) {
@@ -641,7 +641,7 @@ UmlRelation * UmlClass::get_relation(const char * who)
 void UmlClass::replace_friend()
 {
     WrapperStr s;
-    const Q3PtrVector<UmlItem> ch = children();
+    const QVector<UmlItem*> ch = children();
     unsigned i = ch.size();
 
     while (i--) {
@@ -661,7 +661,7 @@ void UmlClass::replace_friend()
 void UmlClass::add_friend(const char * scl)
 {
     WrapperStr s = WrapperStr("  friend class ") + scl + ";\n";
-    const Q3PtrVector<UmlItem> ch = children();
+    const QVector<UmlItem*> ch = children();
     unsigned i = ch.size();
 
     while (i--) {

--- a/src/PlugOutUpgrade/UmlClassView.cpp
+++ b/src/PlugOutUpgrade/UmlClassView.cpp
@@ -2,7 +2,7 @@
 
 void UmlClassView::replace_friend()
 {
-    const Q3PtrVector<UmlItem> ch = children();
+    const QVector<UmlItem*> ch = children();
     unsigned i;
 
     for (i = 0; i != ch.size(); i += 1)

--- a/src/PlugOutUpgrade/UmlItem.cpp
+++ b/src/PlugOutUpgrade/UmlItem.cpp
@@ -6,7 +6,7 @@ UmlItem::~UmlItem()
 
 void UmlItem::rename_jdk5()
 {
-    const Q3PtrVector<UmlItem> ch = children();
+    const QVector<UmlItem*> ch = children();
 
     for (unsigned i = 0; i != ch.size(); i += 1)
         ch[i]->rename_jdk5();
@@ -14,7 +14,7 @@ void UmlItem::rename_jdk5()
 
 void UmlItem::move_after(anItemKind k, const char * name)
 {
-    const Q3PtrVector<UmlItem> ch = parent()->children();
+    const QVector<UmlItem*> ch = parent()->children();
     unsigned i;
 
     for (i = 0; i != ch.size(); i += 1) {

--- a/src/PlugOutUpgrade/UmlOperation.cpp
+++ b/src/PlugOutUpgrade/UmlOperation.cpp
@@ -253,8 +253,8 @@ static bool rename(WrapperStr & s, bool java, bool javasettings)
             int index = 0;
 
             while ((index = s.find(o, index)) != -1) {
-                if (((index == 0) || is_sep(s[index - 1].ascii())) &&
-                    is_sep(s[index + o_len].ascii())) {
+                if (((index == 0) || is_sep(s[index - 1].toLatin1())) &&
+                    is_sep(s[index + o_len].toLatin1())) {
                     s.replace(index, o_len, n);
                     index += n_len;
                     changed = TRUE;

--- a/src/PlugOutUpgrade/UmlPackage.cpp
+++ b/src/PlugOutUpgrade/UmlPackage.cpp
@@ -26,7 +26,6 @@
 // *************************************************************************
 
 #include <qmessagebox.h>
-//Added by qt3to4:
 #include <QList>
 #include "misc/mystr.h"
 
@@ -86,7 +85,7 @@ void upgrade_rename_class(UmlClass * base_item,
   if (!UmlBaseItem::set_Name(s))\n\
     return FALSE;\n\
 \n\
-  const Q3PtrVector<UmlItem> ch = children();\n\
+  const QVector<UmlItem*> ch = children();\n\
   WrapperStr destr = \"~\" + name();\n\
 \n\
   for (unsigned i = 0; i != ch.size(); i += 1) {\n\
@@ -248,7 +247,7 @@ void upgrade_UmlSettings()
 
     for (i = 0; i != sizeof(s) / sizeof(s[0]); i += 1) {
         // add attribute
-        const Q3PtrVector<UmlItem> ch = cl->children();
+        const QVector<UmlItem*> ch = cl->children();
         UmlAttribute * at =
             cl->add_attribute(s[i].att, ProtectedVisibility, "string", 0, 0);
         at->set_isClassMember(TRUE);
@@ -362,7 +361,7 @@ void upgrade_CppSettings()
             cl->add_attribute(s[i].att, PrivateVisibility, "string", 0, 0);
         at->set_isClassMember(TRUE);
 
-        const Q3PtrVector<UmlItem> ch = cl->children();
+        const QVector<UmlItem*> ch = cl->children();
 
         for (j = 0; j != ch.size(); j += 1) {
             if (ch[j]->name() == s[i].after_att) {
@@ -562,7 +561,7 @@ void upgrade_jdk5(UmlClass * javasettings)
 
     UmlPackage::getProject()->rename_jdk5();
 
-    Q3PtrVector<UmlItem> ch = javasettings->children();
+    QVector<UmlItem*> ch = javasettings->children();
     UmlOperation * set_EnumPatternDecl = 0;
     UmlOperation * set_EnumPatternItemCase = 0;
     UmlAttribute * _enum_pattern_decl = 0;
@@ -1176,7 +1175,7 @@ void fixe_package_diagram()
 
     // replace _assoc_diagram
 
-    const Q3PtrVector<UmlItem> ch = basepackage->children();
+    const QVector<UmlItem*> ch = basepackage->children();
     unsigned i;
 
     for (i = 0; i != ch.size(); i += 1) {
@@ -1396,7 +1395,7 @@ void add_object_activity_diagram_item_kind()
     UmlAttribute * anObjectDiagram = itkind->add_enum_item("anObjectDiagram");
     UmlAttribute * anActivityDiagram = itkind->add_enum_item("anActivityDiagram");
 
-    const Q3PtrVector<UmlItem> ch = itkind->children();
+    const QVector<UmlItem*> ch = itkind->children();
 
     for (unsigned i = 0; i != ch.size(); i += 1) {
         if (ch[i]->name() == "aDeploymentDiagram") {
@@ -3257,7 +3256,7 @@ void add_missing_opers()
         op->set_cpp("const Q3PtrVector<${type}>", "",
                     "  UmlCom::send_cmd(miscGlobalCmd, allMarkedCmd);\n"
                     "  \n"
-                    "  Q3PtrVector<UmlItem> result;\n"
+                    "  QVector<UmlItem*> result;\n"
                     "  \n"
                     "  UmlCom::read_item_list(result);\n"
                     "  return result;\n",
@@ -3278,7 +3277,7 @@ void add_missing_opers()
         op->set_cpp("const Q3PtrVector<${type}>", "",
                     "  UmlCom::send_cmd(_identifier, referencedByCmd);\n"
                     "  \n"
-                    "  Q3PtrVector<UmlItem> result;\n"
+                    "  QVector<UmlItem*> result;\n"
                     "  \n"
                     "  UmlCom::read_item_list(result);\n"
                     "  return result;\n",
@@ -3441,7 +3440,7 @@ void replacefriend()
 
 void UmlPackage::replace_friend()
 {
-    const Q3PtrVector<UmlItem> ch = children();
+    const QVector<UmlItem*> ch = children();
     unsigned i;
 
     for (i = 0; i != ch.size(); i += 1)
@@ -3885,7 +3884,7 @@ void fixe_idlsetting_read()
 
 UmlOperation * wrong_umlcom_send_cmd(UmlClass * uml_com)
 {
-    const Q3PtrVector<UmlItem> ch = uml_com->children();
+    const QVector<UmlItem*> ch = uml_com->children();
     UmlOperation * r = 0;
 
     for (unsigned i = 0; i != ch.size(); i += 1) {
@@ -4731,11 +4730,11 @@ void fixe_set_associateddiagram(UmlItem * v)
 
     UmlCom::trace("<b>fixe operations <i>set_AssociatedDiagram</i></b><br>");
 
-    const Q3PtrVector<UmlItem> ch1 = v->children();
+    const QVector<UmlItem*> ch1 = v->children();
 
     for (unsigned i1 = 0; i1 != ch1.size(); i1 += 1) {
         if (ch1[i1]->kind() == aClass) {
-            const Q3PtrVector<UmlItem> ch2 = ch1[i1]->children();
+            const QVector<UmlItem*> ch2 = ch1[i1]->children();
 
             for (unsigned i2 = 0; i2 != ch2.size(); i2 += 1) {
                 if ((ch2[i2]->kind() == anOperation) &&
@@ -4801,7 +4800,7 @@ void bypass_q3ptrvector_bug()
 
     UmlClass::get("UmlBaseArtifact", 0)
     ->get_operation("set_AssociatedClasses")
-    ->set_CppBody("  UmlCom::send_cmd(_identifier, setAssocClassesCmd, (const Q3PtrVector<UmlItem> &) l);\n"
+    ->set_CppBody("  UmlCom::send_cmd(_identifier, setAssocClassesCmd, (const QVector<UmlItem*> &) l);\n"
                   "  if (UmlCom::read_bool()) {\n"
                   "      // tests != to bypass Qt 2.3 bug\n"
                   "    if (_defined && (&_assoc_classes != &l))\n"
@@ -4813,7 +4812,7 @@ void bypass_q3ptrvector_bug()
 
     UmlClass::get("UmlBaseParameterSet", 0)
     ->get_operation("set_Pins")
-    ->set_CppBody("  UmlCom::send_cmd(_identifier, replaceParameterCmd, (const Q3PtrVector<UmlItem> &) v);\n"
+    ->set_CppBody("  UmlCom::send_cmd(_identifier, replaceParameterCmd, (const QVector<UmlItem*> &) v);\n"
                   "  if (UmlCom::read_bool()) {\n"
                   "      // tests != to bypass Qt 2.3 bug\n"
                   "    if (_defined && (&_pins != &v)) _pins = v;\n"
@@ -4843,7 +4842,7 @@ void add_methods(UmlClass * opercl, UmlClass * uml_item)
 
     op->set_isCppConst(TRUE);
     op->set_cpp("const Q3PtrVector<${type}>", "",
-                "  Q3PtrVector<UmlItem> l;\n"
+                "  QVector<UmlItem*> l;\n"
                 "\n"
                 "  UmlCom::send_cmd(_identifier, sideCmd);\n"
                 "  UmlCom::read_item_list(l);\n"
@@ -5373,7 +5372,7 @@ bool ask_for_upgrade()
 void update_api_version(const char * v)
 {
     UmlClass * com = UmlClass::get("UmlCom", 0);
-    const Q3PtrVector<UmlItem> ch = com->children();
+    const QVector<UmlItem*> ch = com->children();
 
     for (unsigned i = 0; i != ch.size(); i += 1) {
         if ((ch[i]->kind() == anOperation) &&

--- a/src/PlugOutUpgrade/activity.cpp
+++ b/src/PlugOutUpgrade/activity.cpp
@@ -39,7 +39,6 @@
 
 #include "util.h"
 #include "activity.h"
-//Added by qt3to4:
 #include <QList>
 #include "misc/mystr.h"
 
@@ -2080,7 +2079,7 @@ void add_pinparam(UmlClassView * base_class_view, UmlClassView * user_class_view
     op->set_Description(" set the pins");
     op->add_param(0, InputDirection, "v", user_activitypin);
     op->set_cpp("${type}", "const Q3PtrVector<${t0}> & ${p0}",
-                "  UmlCom::send_cmd(_identifier, replaceParameterCmd, (const Q3PtrVector<UmlItem> &) v);\n"
+                "  UmlCom::send_cmd(_identifier, replaceParameterCmd, (const QVector<UmlItem*> &) v);\n"
                 "  if (UmlCom::read_bool()) {\n"
                 "    if (_defined) _pins = v;\n"
                 "    return TRUE;\n"
@@ -2139,7 +2138,7 @@ void add_pinparam(UmlClassView * base_class_view, UmlClassView * user_class_view
     op = base_parameterset->add_op("read_uml_", ProtectedVisibility, "void");
     op->set_cpp("${type}", "",
                 "  UmlBaseItem::read_uml_();\n"
-                "  UmlCom::read_item_list((Q3PtrVector<UmlItem> &) _pins);\n",
+                "  UmlCom::read_item_list((QVector<UmlItem*> &) _pins);\n",
                 FALSE, 0, 0);
     op->set_java("${type}", "",
                  "  super.read_uml_();\n"
@@ -2149,7 +2148,7 @@ void add_pinparam(UmlClassView * base_class_view, UmlClassView * user_class_view
 
     // update an UmlCom::send_cmd
 
-    const Q3PtrVector<UmlItem> ch = UmlClass::get("UmlCom", 0)->children();
+    const QVector<UmlItem*> ch = UmlClass::get("UmlCom", 0)->children();
     UmlClass * cl = UmlClass::get("UmlClass", 0);
 
     UmlCom::trace("update UmlCom::send_cmd(...)<br>\n");
@@ -2197,7 +2196,7 @@ void add_pinparam(UmlClassView * base_class_view, UmlClassView * user_class_view
         s = op->cppBody();
 
         if ((index = s.find("l);")) != -1) {
-            s.insert(index, "(const Q3PtrVector<UmlItem> &) ");
+            s.insert(index, "(const QVector<UmlItem*> &) ");
             op->set_CppBody(s);
         }
     }
@@ -3213,7 +3212,7 @@ void add_additionalactions(UmlClass * base_item, UmlClass * user_item)
 
     // replace friends rels
 
-    const Q3PtrVector<UmlItem> ch = base_item->children();
+    const QVector<UmlItem*> ch = base_item->children();
     UmlExtraClassMember * ex = 0;
 
     i = ch.size();

--- a/src/PlugOutUpgrade/instance.cpp
+++ b/src/PlugOutUpgrade/instance.cpp
@@ -247,7 +247,7 @@ void add_class_instance(UmlClassView * base_class_view, UmlClassView * user_clas
     op->add_param(0, OutputDirection, "result", attr);
     op->set_cpp("void", "Q3PtrVector<${t0}> & ${p0}",
                 "  UmlCom::send_cmd(_identifier, attributesCmd, (char) 1);\n"
-                "  UmlCom::read_item_list((Q3PtrVector<UmlItem> &) result);\n",
+                "  UmlCom::read_item_list((QVector<UmlItem*> &) result);\n",
                 FALSE, 0, 0);
     op->set_java("${type}[]", "",
                  "  UmlCom.send_cmd(identifier_(), OnInstanceCmd.attributesCmd, (byte) 1);\n"
@@ -270,7 +270,7 @@ void add_class_instance(UmlClassView * base_class_view, UmlClassView * user_clas
     op->set_cpp("void",
                 "${t0} * ${p0}, Q3PtrVector<${t1}> & ${p1}",
                 "  UmlCom::send_cmd(_identifier, relationsCmd, other->_identifier);\n"
-                "  UmlCom::read_item_list((Q3PtrVector<UmlItem> &) result);\n",
+                "  UmlCom::read_item_list((QVector<UmlItem*> &) result);\n",
                 FALSE, 0, 0);
     op->set_java("${type}[]", "${t0} ${p0}",
                  "  UmlCom.send_cmd(identifier_(), OnInstanceCmd.relationsCmd, other.identifier_());\n"
@@ -310,7 +310,7 @@ void add_class_instance(UmlClassView * base_class_view, UmlClassView * user_clas
     op->add_param(0, InputDirection, "relation", attr);
     op->add_param(1, InputDirection, "other", user_class_instance);
     op->set_cpp("bool", "${t0} * ${p0}, ${t1} * ${p1}",
-                "  Q3PtrVector<UmlItem> v(2);\n"
+                "  QVector<UmlItem*> v(2);\n"
                 "\n"
                 "  v.insert(0, relation);\n"
                 "  v.insert(1, other);\n"
@@ -335,7 +335,7 @@ void add_class_instance(UmlClassView * base_class_view, UmlClassView * user_clas
     op->add_param(0, InputDirection, "relation", attr);
     op->add_param(1, InputDirection, "other", user_class_instance);
     op->set_cpp("bool", "${t0} * ${p0}, ${t1} * ${p1}",
-                "  Q3PtrVector<UmlItem> v(2);\n"
+                "  QVector<UmlItem*> v(2);\n"
                 "\n"
                 "  v.insert(0, relation);\n"
                 "  v.insert(1, other);\n"

--- a/src/PlugOutUpgrade/php.cpp
+++ b/src/PlugOutUpgrade/php.cpp
@@ -862,7 +862,7 @@ void associate_php_artifacts(UmlArtifact * phpsettingsart,
 {
     UmlDeploymentView * dv = (UmlDeploymentView *)
                              UmlClass::get("UmlArtifact", 0)->associatedArtifact()->parent();
-    const Q3PtrVector<UmlItem> ch = dv->children();
+    const QVector<UmlItem*> ch = dv->children();
 
     for (unsigned i = 0; i != ch.size(); i += 1) {
         if ((ch[i]->kind() == anArtifact) && (ch[i]->name() == "executable")) {

--- a/src/PlugOutUpgrade/plug_out_upgrade.pro
+++ b/src/PlugOutUpgrade/plug_out_upgrade.pro
@@ -99,10 +99,10 @@ SOURCES          = util.cpp activity.cpp state.cpp instance.cpp \
     ../Logging/QsDebugOutput.cpp
 
 TARGET          = plug_out_upgrade
-DEFINES          = WITHCPP WITHJAVA WITHPHP WITHIDL WITHPYTHON
+DEFINES          = WITHCPP WITHJAVA WITHPHP WITHIDL WITHPYTHON FALSE=false TRUE=true
 INCLUDEPATH   = ../Tools ../PlugOutUpgrade ../
 #The following line was inserted by qt3to4
-QT += network  qt3support 
+QT += network  widgets
 
 HEADERS += \
     ../Logging/QsLogDest.h \

--- a/src/PlugOutUpgrade/python.cpp
+++ b/src/PlugOutUpgrade/python.cpp
@@ -1017,7 +1017,7 @@ void associate_python_artifacts(UmlArtifact * pythonsettingsart,
 {
     UmlDeploymentView * dv = (UmlDeploymentView *)
                              UmlClass::get("UmlArtifact", 0)->associatedArtifact()->parent();
-    const Q3PtrVector<UmlItem> ch = dv->children();
+    const QVector<UmlItem*> ch = dv->children();
 
     for (unsigned i = 0; i != ch.size(); i += 1) {
         if ((ch[i]->kind() == anArtifact) && (ch[i]->name() == "executable")) {

--- a/src/ProjectControl/projectcontrol.pro
+++ b/src/ProjectControl/projectcontrol.pro
@@ -1,5 +1,5 @@
 TEMPLATE      = app
-CONFIG          += qt warn_on debug
+CONFIG          += qt warn_on
 HEADERS          = BrowserNode.h BrowserView.h BrowserSearchDialog.h \
         ControlWindow.h UserDialog.h
 SOURCES          = main.cpp BrowserNode.cpp ControlWindow.cpp \
@@ -10,5 +10,5 @@ SOURCES          = main.cpp BrowserNode.cpp ControlWindow.cpp \
 TARGET          = projectControl
 DEFINES          = BooL=bool FALSE=false TRUE=true TR=tr
 INCLUDEPATH   = 
-#The following line was inserted by qt3to4
 QT += network widgets
+DESTDIR = ../../bin

--- a/src/ProjectSynchro/projectsynchro.pro
+++ b/src/ProjectSynchro/projectsynchro.pro
@@ -1,5 +1,5 @@
 TEMPLATE      = app
-CONFIG          += qt warn_on debug
+CONFIG          += qt warn_on
 HEADERS          = BrowserNode.h BrowserView.h SynchroWindow.h SynchroDialog.h
 SOURCES          = main.cpp BrowserNode.cpp SynchroWindow.cpp \
         BrowserView.cpp SynchroDialog.cpp Pixmap.cpp myio.cpp 
@@ -9,4 +9,4 @@ TARGET          = projectSynchro
 DEFINES          = BooL=bool FALSE=false TRUE=true TR=tr
 INCLUDEPATH   = 
 QT += network  widgets
-
+DESTDIR = ../../bin

--- a/src/browser/BrowserDeploymentView.cpp
+++ b/src/browser/BrowserDeploymentView.cpp
@@ -327,7 +327,10 @@ void BrowserDeploymentView::exec_menu_choice(int rank)
         BrowserArtifact * dn = BrowserArtifact::add_artifact(this);
 
         if (dn != 0)
+        {
             dn->select_in_browser();
+            dn->open(false);
+        }
     }
     break;
 

--- a/src/browser/BrowserNode.cpp
+++ b/src/browser/BrowserNode.cpp
@@ -2208,6 +2208,30 @@ void BrowserNode::insertItem(BrowserNode *node)
 {
     addChild(node);
 }
+
+void BrowserNode::expandAll()
+{
+    int numChildren = childCount();
+    setExpanded(true);
+    for(int i = 0; i < numChildren; i++)
+    {
+        BrowserNode * node = static_cast <BrowserNode *>(child(i));
+        if(node)
+            node->expandAll();
+    }
+}
+
+void BrowserNode::collapseAll()
+{
+    int numChildren = childCount();
+    setExpanded(false);
+    for(int i = 0; i < numChildren; i++)
+    {
+        BrowserNode * node = static_cast <BrowserNode *>(child(i));
+        if(node)
+            node->collapseAll();
+    }
+}
 //
 
 void BrowserNodeList::sort_it()

--- a/src/browser/BrowserNode.cpp
+++ b/src/browser/BrowserNode.cpp
@@ -104,6 +104,49 @@ QString BrowserNode::FullPathPrefix = "   [";
 QString BrowserNode::FullPathPostfix = "]";
 QString BrowserNode::FullPathDotDot = "::";
 BrowserView* BrowserNode::viewptr = 0;
+
+
+
+class BrowserItemNameValidator: public QValidator{
+public:
+    BrowserItemNameValidator(  BrowserNode* node, UmlCode type,
+                                        bool allow_spaces, bool allow_empty):
+    m_node(node), m_type(type), m_allow_spaces(allow_spaces), m_allow_empty(allow_empty)
+
+    {
+
+    }
+
+private:
+    mutable QString infoMessage;
+    UmlCode m_type;
+    bool m_allow_spaces;
+    bool m_allow_empty;
+    BrowserNode* m_node;
+
+
+
+    // QValidator interface
+public:
+    virtual State validate(QString &str, int &) const;
+    virtual void fixup(QString &) const;
+};
+
+BrowserItemNameValidator::State BrowserItemNameValidator::validate(QString &str, int &) const
+{
+    if (!m_node->wrong_child_name(str, m_type, m_allow_spaces, m_allow_empty, &infoMessage))
+    {
+        infoMessage = tr("Ok");
+        return Acceptable;
+    }
+    return Invalid;
+}
+
+void BrowserItemNameValidator::fixup(QString &str) const
+{
+    str = infoMessage;
+}
+
 BrowserNode::BrowserNode(QString s, BrowserView * parent)
     : QTreeWidgetItem(parent),
       name(s)
@@ -1442,11 +1485,15 @@ bool BrowserNode::enter_child_name(QString & r, const QString & msg, UmlCode typ
 {
     for (;;) {
         BooL ok = FALSE;
-        r = MyInputDialog::getText("Uml", msg, r, ok);
+        BrowserItemNameValidator vl(this, type, allow_spaces, allow_empty);
+        r = MyInputDialog::getTextWithOnlineValidator("Uml", msg, r, ok, &vl);
 
         if (ok) {
-            if (wrong_child_name(r, type, allow_spaces, allow_empty))
-                msg_critical(QObject::tr("Error"), r + "\n\n" + QObject::tr("illegal name or already used"));
+            QString cause;
+            if (wrong_child_name(r, type, allow_spaces, allow_empty, &cause))
+            {
+                msg_critical(QObject::tr("Error"), r + "\n\n" + cause);
+            }
             else
                 return TRUE;
         }
@@ -1472,13 +1519,13 @@ bool BrowserNode::enter_child_name(QString & r, const QString & msg, UmlCode typ
     list.prepend(QString());
 
     *old = 0;
-
+    BrowserItemNameValidator vl(this, type, allow_spaces, allow_empty);
     for (;;) {
         BooL ok = FALSE;
 
         r = (list.count() == 1)
-                ? MyInputDialog::getText("Uml", msg, QString(), ok)
-                : MyInputDialog::getText("Uml", msg, list,  QString(), existing, ok);
+                ? MyInputDialog::getTextWithOnlineValidator("Uml", msg, QString(), ok, &vl)
+                : MyInputDialog::getText("Uml", msg, list,  QString(), existing, ok, &vl);
 
         if (! ok)
             return FALSE;
@@ -1500,10 +1547,16 @@ bool BrowserNode::enter_child_name(QString & r, const QString & msg, UmlCode typ
 }
 
 bool BrowserNode::wrong_child_name( const QString & s, UmlCode type,
-                                    bool allow_spaces, bool allow_empty) const
+                                    bool allow_spaces, bool allow_empty, QString *cause) const
 {
     if (s.isEmpty())
+    {
+        if(cause && !allow_empty)
+        {
+            *cause = QObject::tr("Empty name");
+        }
         return !allow_empty;
+    }
 
     QByteArray sArray = s.toLatin1();
     const char * str = sArray.constData();
@@ -1511,7 +1564,13 @@ bool BrowserNode::wrong_child_name( const QString & s, UmlCode type,
     bool nonUnicodeName = fromUnicode(s) != str  ;
     bool controllable = type >= UmlAssociation && type <= UmlClass;
     if (nonUnicodeName && controllable)
+    {
+        if(cause)
+        {
+            *cause = QObject::tr("Nonunicode name");
+        }
         return true;
+    }
     if (allow_empty)
         // synonymous allowed
         return FALSE;
@@ -1522,37 +1581,19 @@ bool BrowserNode::wrong_child_name( const QString & s, UmlCode type,
         case ' ' :
         case '\t':
         case '\r':
+            if(cause)
+            {
+                *cause = QObject::tr("Name starting with witespace");
+            }
             return TRUE;
 
         default:
             // synonymous allowed
             return FALSE;
         }
-
     default:
         if (type <= UmlClass) {
-#if 0
-            while (*str) {
-                char c = *str++;
 
-                if (((c >= 'a') && (c <= 'z')) ||
-                        ((c >= 'A') && (c <= 'Z')) ||
-                        ((c >= '0') && (c <= '9')) ||
-                        (c == '_'))
-                    ;
-                else if ((strchr("()&^[]%|!+-*/=>", c) != 0) ||
-                         (((c == ' ') || (c == '\t') || (c == '\r')) &&
-                          !allow_spaces))
-                    return TRUE;
-                else if (c == '<') {
-                    if (type == UmlClass)
-                        // suppose it is a valid template
-                        break;
-                    else
-                        return TRUE;
-                }
-            }
-#else
             for (QString::const_iterator it = s.begin(); it != s.end(); ++it) {
                 char c = (*it).toLatin1();
 
@@ -1564,16 +1605,27 @@ bool BrowserNode::wrong_child_name( const QString & s, UmlCode type,
                 else if ((strchr("()&^[]%|!+-*/=>", c) != 0) ||
                          (((c == ' ') || (c == '\t') || (c == '\r')) &&
                           !allow_spaces))
+                {
+                    if(cause)
+                    {
+                        *cause = QObject::tr("Name containing illegal character: ") + c;
+                    }
                     return TRUE;
+                }
                 else if (c == '<') {
                     if (type == UmlClass)
                         // suppose it is a valid template
                         break;
                     else
+                    {
+                        if(cause)
+                        {
+                            *cause = QObject::tr("Name containing illegal character: ") + c;
+                        }
                         return TRUE;
+                    }
                 }
             }
-#endif
         }
     }
 
@@ -1583,7 +1635,13 @@ bool BrowserNode::wrong_child_name( const QString & s, UmlCode type,
     {
         if (!((BrowserNode *) child)->deletedp() &&
                 ((BrowserNode *) child)->same_name(s, type))
+        {
+            if(cause)
+            {
+                *cause = QObject::tr("Name already used");
+            }
             return TRUE;
+        }
     }
 
 

--- a/src/browser/BrowserNode.h
+++ b/src/browser/BrowserNode.h
@@ -317,6 +317,8 @@ public:
     void moveItem(BrowserNode *after);
     void takeItem(BrowserNode *node);
     void insertItem(BrowserNode *node);
+    void expandAll();
+    void collapseAll();
 };
 
 inline QString BrowserNode::fullname(bool rev) const

--- a/src/browser/BrowserNode.h
+++ b/src/browser/BrowserNode.h
@@ -192,7 +192,7 @@ public:
                           bool allow_spaces, bool allow_empty,
                           bool exiting = false);
     bool wrong_child_name(const QString & s, UmlCode type,
-                          bool allow_spaces, bool allow_empty) const;
+                          bool allow_spaces, bool allow_empty, QString *cause = NULL) const;
     virtual bool allow_spaces() const;
     virtual bool allow_empty() const;
     virtual bool same_name(const QString & s, UmlCode type) const;

--- a/src/diagram/BrowserView.cpp
+++ b/src/diagram/BrowserView.cpp
@@ -488,6 +488,14 @@ void BrowserView::keyPressEvent(QKeyEvent * e)
                     bn->apply_shortcut("Delete");
                     QApplication::restoreOverrideCursor();
                 }
+                else if(s == "Expand All")
+                {
+                    bn->expandAll();
+                }
+                else if(s == "Collapse All")
+                {
+                    bn->collapseAll();
+                }
                 else if ((s != "Move left") && (s != "Move right") &&
                          (s != "Move up") && (s != "Move down"))
                     bn->apply_shortcut(s);

--- a/src/diagram/BrowserView.cpp
+++ b/src/diagram/BrowserView.cpp
@@ -133,7 +133,8 @@ void BrowserView::clear()
 void BrowserView::set_project(const QDir & di)
 {
     dir = di;
-    project = new BrowserPackage(dir.dirName(), the, PROJECT_ID);
+    project = new BrowserPackage(dir.dirName(), (BrowserView *) 0, PROJECT_ID);
+    the->addTopLevelItem(project);
     setRootIsDecorated(FALSE);
 }
 

--- a/src/diagram/StateCanvas.cpp
+++ b/src/diagram/StateCanvas.cpp
@@ -390,7 +390,8 @@ void StateCanvas::resize(aCorner c, int dx, int dy, QPoint & o)
 {
     DiagramCanvas::resize(c, dx, dy, o, min_width, min_height, TRUE);
 
-    force_sub_inside(FALSE);
+    //do not move internal items while resize
+    //force_sub_inside(FALSE);
 }
 
 void StateCanvas::resize(const QSize & sz, bool w, bool h)

--- a/src/dialog/MyInputDialog.cpp
+++ b/src/dialog/MyInputDialog.cpp
@@ -138,7 +138,10 @@ MyInputDialog::MyInputDialog(const char * title, const QString & msg,
         lb = new QLabel(this);
         lb->setAlignment(Qt::AlignCenter);
         vbox->addWidget(lb);
-        connect(cb->lineEdit(), SIGNAL(textChanged(QString)), this, SLOT(onTextChanged()));
+        if(cb->isEditable())
+            connect(cb->lineEdit(), SIGNAL(textChanged(QString)), this, SLOT(onTextChanged()));
+        else
+            connect(cb, SIGNAL(currentTextChanged(QString)), this, SLOT(onTextChanged()));
     }
     hbox = new QHBoxLayout();
     vbox->addLayout(hbox);
@@ -248,14 +251,18 @@ void MyInputDialog::onTextChanged()
     }
     else if(cb)
     {
-        if(cb->lineEdit()->hasFocus())
+        if(cb->isEditable())
         {
-            //loose and regain focus so that cb compare current text with items' text to set current index
-            this->setFocus();
-            cb->lineEdit()->setFocus();
+            if(cb->hasFocus())
+            {
+                //loose and regain focus so that cb compare current text with items' text to set current index
+                this->setFocus();
+                cb->setFocus();
+            }
+            pos = cb->lineEdit()->cursorPosition();
         }
+
         text = cb->currentText();
-        pos = cb->lineEdit()->cursorPosition();
 
         if (!text.isEmpty()) {
             int index = cb->currentIndex();

--- a/src/dialog/MyInputDialog.h
+++ b/src/dialog/MyInputDialog.h
@@ -38,7 +38,8 @@ class QComboBox;
 class QValidator;
 
 class LineEdit;
-
+class QLabel;
+class QValidator;
 class MyInputDialog : public QDialog
 {
     Q_OBJECT
@@ -46,26 +47,37 @@ class MyInputDialog : public QDialog
 protected:
     LineEdit * le;
     QComboBox * cb;
+    QLabel * lb;
+    const QValidator *vl;
 
     static QSize previous_size;
 
     MyInputDialog(const char * title, const QString & msg,
                   const QString & init);
     MyInputDialog(const char * title, const QString & msg,
-                  const QStringList & l, const QString & init, bool existing);
+                  const QStringList & l, const QString & init, bool existing, const QValidator * v = 0);
+    MyInputDialog(const char * title, const QString & msg,
+                                 const QString & init, QValidator *validator);
     virtual ~MyInputDialog();
 
 public:
+    static QString getTextWithOnlineValidator(const char * title, const QString & msg,
+                                   const QString & init, BooL & ok,
+                                   QValidator * v);
     static QString getText(const char * title, const QString & msg,
                            const QString & init, BooL & ok,
                            const QValidator * v = 0);
     static QString getText(const char * title, const QString & msg,
                            const QStringList & l, const QString & init,
-                           bool existing, BooL & ok);
+                           bool existing, BooL & ok,
+                           const QValidator * v = NULL);
 
 protected slots:
     virtual void polish();
     virtual void accept();
+    void onTextChanged();
+private:
+    QPushButton * ok;
 };
 
 #endif

--- a/src/dialog/tabdialog.cpp
+++ b/src/dialog/tabdialog.cpp
@@ -17,6 +17,7 @@ TabDialog::TabDialog(QWidget *parent, const char *name, bool modal, Qt::WidgetAt
     m_buttonLayout = new QHBoxLayout();
     layout->addWidget(m_tabWidget);
     layout->addLayout(m_buttonLayout);
+    connect(m_tabWidget, SIGNAL(currentChanged(int)), this, SLOT(onCurrentTabChanged(int)));
 
 
 }
@@ -34,6 +35,11 @@ void TabDialog::insertTab(QWidget *tabWidget, QString name, int index)
 void TabDialog::setTabEnabled(QWidget *w, bool isEnabled)
 {
     m_tabWidget->setTabEnabled(m_tabWidget->indexOf(w), isEnabled);
+}
+
+void TabDialog::onCurrentTabChanged(int i)
+{
+    emit currentChanged(m_tabWidget->widget(i));
 }
 void TabDialog::removePage(QWidget *page)
 {

--- a/src/dialog/tabdialog.h
+++ b/src/dialog/tabdialog.h
@@ -25,8 +25,10 @@ public:
 
     void setTabEnabled(QWidget *w, bool isEnabled);
 signals:
+    void currentChanged(QWidget *);
     void helpButtonPressed();
 public slots:
+    void onCurrentTabChanged(int i);
 private:
 protected:
     QTabWidget* m_tabWidget;

--- a/src/misc/Shortcut.cpp
+++ b/src/misc/Shortcut.cpp
@@ -229,7 +229,9 @@ void Shortcut::init(bool conv)
         "Upper",
         "Zoom +",
         "Zoom -",
-        "Zoom 100%"
+        "Zoom 100%",
+        "Expand All",
+        "Collapse All"
     };
 
     for (i = 0; i != sizeof(cmds) / sizeof(cmds[0]); i += 1)

--- a/src/ui/bbuttongroup.cpp
+++ b/src/ui/bbuttongroup.cpp
@@ -10,6 +10,7 @@ BButtonGroup::BButtonGroup(QWidget *parent) :
     this->setLayout(m_hLayout);
     m_hLayout->setSpacing(0);
     m_hLayout->setMargin(0);
+    connect(&m_buttonGroup, SIGNAL(buttonClicked(int)), this, SIGNAL(clicked(int)));
 }
 
 BButtonGroup::BButtonGroup(const QString &title, QWidget *parent):
@@ -52,14 +53,15 @@ void BButtonGroup::setExclusive(bool isEx)
 
 }
 
-void BButtonGroup::addWidget(QWidget *widget)
+void BButtonGroup::addWidget(QAbstractButton *widget)
 {
+    m_buttonGroup.addButton(widget);
     if(m_orientation == Qt::Horizontal)
     {
-        m_hLayout->addWidget(widget);
+        m_hLayout->addWidget((QWidget*)widget);
     }
     else
     {
-        m_vLayout->addWidget(widget);
+        m_vLayout->addWidget((QWidget*)widget);
     }
 }

--- a/src/ui/bbuttongroup.h
+++ b/src/ui/bbuttongroup.h
@@ -5,6 +5,7 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <QButtonGroup>
 class BButtonGroup : public QGroupBox
 {
     Q_OBJECT
@@ -13,13 +14,15 @@ public:
     explicit BButtonGroup(const QString &title, QWidget* parent=0);
     BButtonGroup( int strips, Qt::Orientation orientation, const QString & title, QWidget * parent = 0, QString = QString());
     void setExclusive(bool isEx);
-    void addWidget(QWidget* widget);
+    void addWidget(QAbstractButton *widget);
     QHBoxLayout *m_hLayout;
     QHBoxLayout *m_vLayout;
     Qt::Orientation m_orientation;
 signals:
-
+    void clicked(int);
 public slots:
+private:
+    QButtonGroup m_buttonGroup;
 
 };
 


### PR DESCRIPTION
- "Expand/Collapse All"  feature is added as shortcut key. Setting this shortcut, a user can expand/collapse all the child nodes of active node in browser. 
- Item name validity is changed to online, instead of checking it fter pressing OK button.
- Artifact dialog is opened after adding a new artifact using browser context menu.
- "debug" keyword removed from some plugout project files.
- missing clicked signal added to BButtonGroup class
- Crash on QDialog::exec call is fixed
- PlugOutUpgrade project is made compilable by Qt5
- missing currentChanged(QWidget*) added to TabDialog