### PR TITLE
Building on OS X El Capitan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ src/CppReverse/cpp_reverse
 !src/settings_ini.h
 /install/
 .DS_Store
+.qmake.stash

--- a/src/CppReverse/ClassContainer.cpp
+++ b/src/CppReverse/ClassContainer.cpp
@@ -352,7 +352,7 @@ bool ClassContainer::find_type(WrapperStr type, UmlTypeSpec & typespec,
                 }
             }
 
-            if ((type[index2] != (char)0) && (defined[type.left(index2)] != (char)0))
+            if ((type[index2] != (char)0) && (defined[type.left(index2)] != 0))
                 // explicit template
                 index = index2;
             else if (defined[type.left(index)] != 0)

--- a/src/JavaCat/Progress.cpp
+++ b/src/JavaCat/Progress.cpp
@@ -36,7 +36,7 @@
 Progress * Progress::it = 0;
 
 Progress::Progress(int n, const char * lbl, QApplication * a)
-    : QProgressDialog(0, 0, n, 0, 0, FALSE), n(0), app(a)
+    : QProgressDialog(0, 0, 0, n, 0, 0), n(0), app(a)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     if (it != 0)

--- a/src/PhpReverse/Progress.cpp
+++ b/src/PhpReverse/Progress.cpp
@@ -33,7 +33,7 @@
 #include "Package.h"
 
 Progress::Progress(int n, const char * lbl)
-    : QProgressDialog(lbl, 0, n, 0, 0, FALSE), n(0)
+    : QProgressDialog(lbl, 0, 0, n, 0, 0), n(0)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setMinimumDuration(1000);

--- a/src/diagram/UmlWindow.h
+++ b/src/diagram/UmlWindow.h
@@ -96,6 +96,7 @@ protected:
     QMenu * projectMenu;
     QMenu * windowsMenu;
     QMenu * toolMenu;
+	bool isToolMenuLoaded;
     QMenu * langMenu;
     QMenu * miscMenu;
     QMenu * fontSizeMenu;

--- a/src/dialog/EnvDialog.cpp
+++ b/src/dialog/EnvDialog.cpp
@@ -198,7 +198,7 @@ EnvDialog::EnvDialog(bool conv, bool noid)
         grid->addWidget(new QLabel(tr("\nOptional, to indicate a character set in case you use non ISO_8859-1/latin1 characters. For instance KOI8-R or KOI8-RU for Cyrillic")),13,1);
 
         grid->addWidget(new QLabel(tr("Character set ")),14,0);
-        cb_charset = new QComboBox(FALSE);
+        cb_charset = new QComboBox();
         grid->addWidget(cb_charset,14,1);
         cb_charset->setAutoCompletion(completion());
         QStringList l;

--- a/src/dialog/ShortcutDialog.cpp
+++ b/src/dialog/ShortcutDialog.cpp
@@ -86,7 +86,7 @@ ShortcutDialog::ShortcutDialog() : TabDialog(0, 0, TRUE)
     vtab->addWidget((new QLabel(tr("Here are the shortcuts to do a command (menu entry)"), vtab)));
 
 #ifdef __APPLE__
-    (new QLabel(TR("Note : sometimes the key 'Alt' is named 'Option'"), vtab))
+    (new QLabel(tr("Note : sometimes the key 'Alt' is named 'Option'"), vtab))
             ->setAlignment(::Qt::AlignHCenter);
 #endif
 
@@ -105,7 +105,7 @@ ShortcutDialog::ShortcutDialog() : TabDialog(0, 0, TRUE)
     label->setAlignment(::Qt::AlignHCenter);
 
 #ifdef __APPLE__
-    (new QLabel(TR("Note : sometimes the key 'Alt' is named 'Option'"), vtab))
+    (new QLabel(tr("Note : sometimes the key 'Alt' is named 'Option'"), vtab))
             ->setAlignment(::Qt::AlignHCenter);
 
 #endif
@@ -156,10 +156,11 @@ ShortcutTable::ShortcutTable(QWidget * parent, bool tool, int n)
     QStringList headerLabels;
     headerLabels.append(tr("Shift"));
 #ifdef __APPLE__
-#include "../xpm/pomme_xpm.xpm"
-    QPixmap pomme_xpm((const char **) pomme);
-    QIcon ic(pomme_xpm);
-    headerLabels.append(ic, "");
+	//#include "../xpm/pomme_xpm.xpm"
+	//    QPixmap pomme_xpm((const char **) pomme);
+	//    QIcon ic(pomme_xpm);
+	//    headerLabels.append(ic, "");
+    headerLabels.append(tr("Cmd"));
 #else
     headerLabels.append(tr("Ctrl"));
 #endif


### PR DESCRIPTION
Minor changes and fixes to allow building on OS X El Capitan. I briefly tested the resulting douml executable : I could successfully open an old very small project created years ago with at-the-time free Bouml. I edited it, added classes and attributes and saved it. The modified project then opened successfully in Bouml Viewer 6.10.